### PR TITLE
Fix DM visibility: show all DMs without needing active conversation

### DIFF
--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -791,8 +791,8 @@ export class SocialScreen implements Screen {
 
   /** Request chat history for a channel if not already loaded. */
   private loadChatHistory(type: ChatChannelType, id: string): void {
-    if (!id) return;
-    const key = `${type}:${id}`;
+    if (!id && type !== 'dm') return;
+    const key = `${type}:${id || '_all'}`;
     if (this.chatHistoryLoaded.has(key)) return;
     this.chatHistoryLoaded.add(key);
     this.gameClient.sendRequestChatHistory(type, id);
@@ -842,9 +842,13 @@ export class SocialScreen implements Screen {
             : filtered.map(m => {
               const ch = SocialScreen.CHAT_CHANNELS.find(c => c.type === m.channelType);
               const tag = ch?.tag ?? '?';
+              const selfName = this.lastState?.username ?? '';
+              // For DMs sent by the current user, show "to: recipient"
+              const dmTo = (m.channelType === 'dm' && m.senderUsername === selfName)
+                ? ` <span class="chat-dm-to">to ${this.escapeHtml(m.channelId)}</span>` : '';
               return `<div class="social-chat-msg">
                 <span class="chat-tag chat-color-${m.channelType}">[${tag}]</span>
-                <span class="social-chat-sender chat-color-${m.channelType}">${this.escapeHtml(m.senderUsername)}</span>
+                <span class="social-chat-sender chat-color-${m.channelType}">${this.escapeHtml(m.senderUsername)}${dmTo}</span>
                 <span class="social-chat-text">${this.escapeHtml(m.text)}</span>
               </div>`;
             }).join('')

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -1666,6 +1666,11 @@ html, body {
   margin-right: 6px;
 }
 
+.chat-dm-to {
+  opacity: 0.7;
+  font-size: 7px;
+}
+
 .social-chat-text {
   color: var(--text-primary);
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -472,10 +472,15 @@ wss.on('connection', (ws) => {
         // Return from the player's personal chat history
         let messages: ChatMessage[];
         if (channelType === 'dm') {
-          // For DMs, filter by channelType and match either direction
-          messages = session.getChatHistory().filter(m =>
-            m.channelType === 'dm' && (m.channelId === channelId || m.senderUsername === channelId)
-          );
+          if (channelId) {
+            // For DMs with a specific target, match either direction
+            messages = session.getChatHistory().filter(m =>
+              m.channelType === 'dm' && (m.channelId === channelId || m.senderUsername === channelId)
+            );
+          } else {
+            // No target specified — return ALL DMs
+            messages = session.getChatHistory().filter(m => m.channelType === 'dm');
+          }
         } else {
           messages = session.getChatHistory(channelType);
         }


### PR DESCRIPTION
## Summary
- **Server**: When requesting DM history without a specific target, return all DMs instead of nothing
- **Client**: Load all DM history when the chat tab opens, even without an active DM conversation
- **Client**: Sent DMs now show a "to: recipient" indicator so you can tell who each message was for

Closes #4

## Test plan
- [ ] Open chat tab without starting a DM — all past DMs should be visible
- [ ] Toggle the DM filter pill — DMs from all conversations appear/disappear
- [ ] Send a DM — verify "to: username" appears next to your name in the chat log
- [ ] Incoming DMs should still display normally (sender name, no "to:" indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)