### PR TITLE
Fix stale combat screen when switching devices

### DIFF
--- a/client/src/network/GameClient.ts
+++ b/client/src/network/GameClient.ts
@@ -42,7 +42,16 @@ export class GameClient {
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
         this.isInitialState = true;
-        this.sendRaw({ type: 'request_state' });
+        if (this.ws?.readyState === WebSocket.OPEN) {
+          this.sendRaw({ type: 'request_state' });
+        } else if (this.connected && !this.destroyed) {
+          // WebSocket died while in background — reconnect immediately
+          if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = undefined;
+          }
+          this.doConnect();
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- When switching devices, the background device's WebSocket often disconnects. The `visibilitychange` handler was calling `sendRaw({ type: 'request_state' })` which silently failed on a dead socket, leaving the combat screen showing stale party data.
- Now checks the WebSocket state on visibility change — if the socket is dead, cancels any pending reconnect timer and forces an immediate reconnect, so the user gets fresh state right away.

## Test plan
- [ ] Open the game on two devices logged into the same account
- [ ] On Device A, join a party (accept an invite)
- [ ] Put Device B in background briefly, then bring it back — should show updated party members without needing a page refresh

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)