### PR TITLE
Split rewards among party members

### DIFF
--- a/server/src/game/PartyBattleManager.ts
+++ b/server/src/game/PartyBattleManager.ts
@@ -6,6 +6,8 @@ import {
   createPartyCombatState,
   createEncounter,
   getZone,
+  MONSTERS,
+  rollDrops,
 } from '@idle-party-rpg/shared';
 import type {
   BattleResult,
@@ -350,13 +352,57 @@ export class PartyBattleManager {
     const entry = this.entries.get(partyId);
     if (!entry) return;
 
-    for (const username of entry.members) {
-      const session = this.getSession(username);
-      if (!session) continue;
+    if (result === 'victory') {
+      const combat = entry.battleTimer.currentCombat;
+      const members = Array.from(entry.members);
+      const partySize = members.length;
 
-      if (result === 'victory') {
-        session.handleVictory(entry.battleTimer.currentCombat, entry.serverParty.tile);
-      } else {
+      // Compute total XP and gold once, then split
+      const totalXp = combat
+        ? combat.monsters.reduce((sum, m) => sum + m.xp, 0)
+        : 10;
+      let totalGold = 0;
+      if (combat) {
+        for (const m of combat.monsters) {
+          const def = MONSTERS[m.id];
+          if (def) {
+            totalGold += def.goldMin + Math.floor(Math.random() * (def.goldMax - def.goldMin + 1));
+          }
+        }
+      }
+
+      const splitXp = Math.ceil(totalXp / partySize);
+      const splitGold = Math.ceil(totalGold / partySize);
+
+      // Roll item drops once, randomly assign each to a party member
+      const memberItems: Map<string, string[]> = new Map();
+      for (const u of members) memberItems.set(u, []);
+
+      if (combat) {
+        for (const m of combat.monsters) {
+          const def = MONSTERS[m.id];
+          if (def?.drops) {
+            const dropped = rollDrops(def.drops);
+            for (const itemId of dropped) {
+              const recipient = members[Math.floor(Math.random() * partySize)];
+              memberItems.get(recipient)!.push(itemId);
+            }
+          }
+        }
+      }
+
+      for (const username of members) {
+        const session = this.getSession(username);
+        if (!session) continue;
+        session.handleVictory(
+          { xp: splitXp, gold: splitGold, items: memberItems.get(username)! },
+          entry.serverParty.tile,
+        );
+      }
+    } else {
+      for (const username of entry.members) {
+        const session = this.getSession(username);
+        if (!session) continue;
         session.addLogEntry('Defeat...', 'defeat');
       }
     }

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -11,10 +11,8 @@ import {
   addGold,
   calculateMaxHp,
   xpForNextLevel,
-  MONSTERS,
   ITEMS,
   computeEquipmentBonuses,
-  rollDrops,
   addItemToInventory,
   equipItem,
   unequipItem,
@@ -30,7 +28,6 @@ import type {
   CharacterState,
   ClassName,
   StatName,
-  PartyCombatState,
   PartyCombatant,
   ClientCharacterState,
   EquipSlot,
@@ -116,8 +113,8 @@ export class PlayerSession {
     };
   }
 
-  /** Handle victory rewards (called by PartyBattleManager). */
-  handleVictory(combat: PartyCombatState | null, tile: HexTile): void {
+  /** Handle victory rewards (called by PartyBattleManager with pre-split rewards). */
+  handleVictory(rewards: { xp: number; gold: number; items: string[] }, tile: HexTile): void {
     this.addLogEntry('Victory!', 'victory');
 
     const unlocked = this.unlockSystem.unlockAdjacentTiles(tile);
@@ -125,44 +122,20 @@ export class PlayerSession {
       this.addLogEntry(`${unlocked.length} new room${unlocked.length > 1 ? 's' : ''} unlocked!`, 'unlock');
     }
 
-    // Award XP based on monsters defeated
-    const xpGained = combat
-      ? combat.monsters.reduce((sum, m) => sum + m.xp, 0)
-      : 10;
-
-    // Award gold based on monsters defeated
-    let goldGained = 0;
-    if (combat) {
-      for (const m of combat.monsters) {
-        const def = MONSTERS[m.id];
-        if (def) {
-          goldGained += def.goldMin + Math.floor(Math.random() * (def.goldMax - def.goldMin + 1));
-        }
-      }
-    }
-    if (goldGained > 0) {
-      addGold(this.character, goldGained);
-      this.addLogEntry(`+${goldGained} Gold`, 'victory');
+    if (rewards.gold > 0) {
+      addGold(this.character, rewards.gold);
+      this.addLogEntry(`+${rewards.gold} Gold`, 'victory');
     }
 
-    // Roll item drops per monster
-    if (combat) {
-      for (const m of combat.monsters) {
-        const def = MONSTERS[m.id];
-        if (def?.drops) {
-          const dropped = rollDrops(def.drops);
-          for (const itemId of dropped) {
-            const itemDef = ITEMS[itemId];
-            if (itemDef && addItemToInventory(this.character.inventory, itemId)) {
-              this.addLogEntry(`Found ${itemDef.name}!`, 'victory');
-            }
-          }
-        }
+    for (const itemId of rewards.items) {
+      const itemDef = ITEMS[itemId];
+      if (itemDef && addItemToInventory(this.character.inventory, itemId)) {
+        this.addLogEntry(`Found ${itemDef.name}!`, 'victory');
       }
     }
 
-    const { leveledUp, levelsGained } = addXp(this.character, xpGained);
-    this.addLogEntry(`+${xpGained} XP`, 'victory');
+    const { leveledUp, levelsGained } = addXp(this.character, rewards.xp);
+    this.addLogEntry(`+${rewards.xp} XP`, 'victory');
     if (leveledUp) {
       for (let i = 0; i < levelsGained; i++) {
         this.addLogEntry(`Level up! Now level ${this.character.level - levelsGained + i + 1}!`, 'levelup');


### PR DESCRIPTION
## Summary
- XP and gold from battles are now divided by party size, rounded up (e.g. 8 gold / 5 players = 2 each)
- Item drops are rolled once per battle and randomly assigned to individual party members
- Reward computation moved from `PlayerSession` to `PartyBattleManager` so splitting happens before distribution

Closes #19

## Test plan
- [x] All 187 existing tests pass
- [x] Typecheck clean
- [ ] Manual: verify solo player rewards unchanged
- [ ] Manual: verify party rewards are split correctly in combat log

🤖 Generated with [Claude Code](https://claude.com/claude-code)