### PR TITLE
Fix chat scroll position loss and mobile keyboard overlap

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,3 +2,18 @@ import './styles/pixel-theme.css';
 import { App } from './App';
 
 new App();
+
+// Resize #app when the mobile virtual keyboard opens/closes.
+// visualViewport shrinks when the keyboard appears; we match #app to it
+// so the bottom nav and chat input stay visible above the keyboard.
+if (window.visualViewport) {
+  const app = document.getElementById('app')!;
+  const onViewportResize = () => {
+    const vv = window.visualViewport!;
+    app.style.height = `${vv.height}px`;
+    // Offset top in case the viewport scrolled (iOS Safari)
+    app.style.transform = `translateY(${vv.offsetTop}px)`;
+  };
+  window.visualViewport.addEventListener('resize', onViewportResize);
+  window.visualViewport.addEventListener('scroll', onViewportResize);
+}

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -826,7 +826,8 @@ export class SocialScreen implements Screen {
 
     // Capture scroll position before re-render
     const oldMsgContainer = this.panelContainer.querySelector('.social-chat-messages');
-    const wasAtBottom = !oldMsgContainer || (oldMsgContainer.scrollTop + oldMsgContainer.clientHeight >= oldMsgContainer.scrollHeight - 20);
+    const oldScrollTop = oldMsgContainer ? oldMsgContainer.scrollTop : 0;
+    const wasAtBottom = !oldMsgContainer || (oldScrollTop + oldMsgContainer.clientHeight >= oldMsgContainer.scrollHeight - 20);
 
     this.panelContainer.innerHTML = `
       <div class="social-chat-container">
@@ -869,10 +870,14 @@ export class SocialScreen implements Screen {
       </div>
     `;
 
-    // Auto-scroll only if user was already at the bottom
+    // Restore scroll position: auto-scroll to bottom if user was there, otherwise preserve position
     const msgContainer = this.panelContainer.querySelector('.social-chat-messages');
-    if (msgContainer && wasAtBottom) {
-      msgContainer.scrollTop = msgContainer.scrollHeight;
+    if (msgContainer) {
+      if (wasAtBottom) {
+        msgContainer.scrollTop = msgContainer.scrollHeight;
+      } else {
+        msgContainer.scrollTop = oldScrollTop;
+      }
     }
 
     // Wire filter toggles


### PR DESCRIPTION
## Summary
- **Chat scroll fix**: Preserved `scrollTop` across re-renders so the chat no longer jumps to the top when the user is scrolled up reading history. Auto-scroll to bottom still works when already at the bottom.
- **Mobile keyboard fix**: Added a `visualViewport` listener that resizes `#app` when the virtual keyboard opens, keeping the bottom nav and chat input visible above the keyboard on both iOS and Android.

Fixes #18

## Test plan
- [ ] Open chat, scroll up, verify new messages don't reset scroll position to top
- [ ] Open chat at bottom, verify new messages auto-scroll as before
- [ ] On mobile, tap chat input — verify bottom nav and input bar remain visible above the keyboard
- [ ] On desktop, verify no visual changes from the viewport listener (no-op when no keyboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)