### PR TITLE
Add content versioning, deploy safety, and live world updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ server/                        @idle-party-rpg/server — Node.js game server
 │       ├── ServerParty.ts     # Server party state (no rendering)
 │       ├── GameStateStore.ts  # GameStateStore interface + PlayerSaveData type
 │       ├── JsonFileStore.ts   # JSON-file-based persistence (data/<username>.json)
+│       ├── VersionStore.ts    # Content version snapshots (data/versions/)
 │       └── social/
 │           ├── FriendsSystem.ts # Friend request system (send/accept/decline/revoke, two-way)
 │           ├── GuildSystem.ts   # Guild create/join/leave/invite (level 20+ to create)
@@ -124,6 +125,7 @@ data/                          Persistent runtime data (gitignored, created at r
 ├── items.json                 # Item definitions (loaded by ContentStore, auto-seeded)
 ├── zones.json                 # Zone definitions (loaded by ContentStore, auto-seeded)
 ├── world.json                 # World map tile definitions (loaded by ContentStore, auto-seeded)
+├── versions/                  # Version snapshots
 └── sessions/                  # Express session files (one .json per session)
 
 deploy/                        Deployment config files
@@ -225,8 +227,13 @@ Everything in `data/` is persisted behind a **swappable interface** so the stora
 - **Guilds**: `GuildStore` reads/writes `data/guilds.json`
 - **Game content**: `ContentStore` reads/writes `data/monsters.json`, `data/items.json`, `data/zones.json`, `data/world.json`. Auto-seeds from `SEED_*` constants if files missing.
 - **Chat**: Stored per-player in `PlayerSaveData.chatHistory` (saved with each player's JSON file)
+- **Versions**: `VersionStore` reads/writes `data/versions/manifest.json` + `data/versions/{id}.json`
 
 When adding new persistent data to `data/`, always define an interface or extend an existing one. Never read/write files directly from game logic — go through the store abstraction.
+
+## Content Versioning
+
+- **Content versioning**: Admin content edits go through a draft→publish→deploy pipeline. `VersionStore` manages version metadata (`data/versions/manifest.json`) and snapshots (`data/versions/{id}.json`). Each snapshot freezes all game content (monsters, items, zones, world). On deploy, `GameLoop.deployVersion()` replaces live content, rebuilds the hex grid, and relocates parties on unreachable tiles. When adding new content types to the game, they must be included in `ContentSnapshot` (`VersionStore.ts`) and `ContentStore.toSnapshot()`/`replaceAll()`.
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ data/             Runtime JSON content files (monsters, items, zones, world map 
 
 TypeScript throughout. Vite for client bundling. Express + ws for the server.
 
+## Content Versioning
+
+Admin content changes (monsters, items, zones, world map tiles) go through a **draft → publish → deploy** pipeline managed from the Versions tab in the World Manager admin panel. Edits are made freely against a draft version — nothing affects the live game until the admin explicitly publishes and deploys.
+
+Publishing a draft creates an **immutable snapshot** of all content at that point in time. Published versions cannot be edited; to make further changes the admin creates a new draft. This gives a clear history of every content release and makes rollbacks straightforward.
+
+**Deploying** a published version swaps it into the live game. The server hot-reloads the new content so players see updated zones, monsters, and map tiles without a restart. If a deployed version removes tiles that players are currently standing on, those players are automatically relocated to the nearest valid tile.
+
 ## Roadmap
 
 ### World Map
@@ -198,15 +206,16 @@ Real-time auto-battle with tick-based damage (1s per tick), HP tracked for both 
 - [x] Mobile zoom controls (+/- buttons on map)
 - [x] Tile click modal (tile info, "Move here" button, players on tile)
 
-### Game Manager
+### World Manager
 - [x] Separate admin client (World Manager dashboard at /admin)
+- [x] Content versioning (draft→publish→deploy pipeline with immutable snapshots)
 - [ ] Monster editor
 - [ ] Area/zone editor
 - [ ] Quest editor
 - [ ] Game designer access only
 
 ### Infrastructure
-- [x] Monorepo structure (client/, server/, game-manager/)
+- [x] Monorepo structure (client/, server/)
 - [x] Single `npm run dev` runs all subprojects
 - [x] Test coverage
 - [x] Shared types package between client/server

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -300,6 +300,13 @@ export class App {
       socialScreen.startDm(username);
     });
 
+    // Listen for world content updates (admin deployed a new version)
+    this.gameClient.onWorldUpdate(async () => {
+      console.log('[App] World updated — reloading world data');
+      await this.worldCache.loadWorld();
+      mapScreen.refreshWorld();
+    });
+
     this.screenManager.register('combat', document.getElementById('screen-combat')!, combatScreen);
     this.screenManager.register('map', document.getElementById('screen-map')!, mapScreen);
     this.screenManager.register('character', document.getElementById('screen-character')!, characterScreen);

--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -1,12 +1,16 @@
 import {
-  HexGrid,
   HexTile,
   offsetToCube,
   cubeToPixel,
+  pixelToCube,
   cubeToOffset,
+  cubeEquals,
   getHexCorners,
+  getNeighbors,
+  getNeighbor,
   TILE_CONFIGS,
   HEX_SIZE,
+  TileType,
 } from '@idle-party-rpg/shared';
 import type {
   MonsterDefinition,
@@ -14,7 +18,20 @@ import type {
   ZoneDefinition,
   WorldTileDefinition,
   WorldData,
+  CubeCoord,
 } from '@idle-party-rpg/shared';
+
+// Maps CUBE_DIRECTIONS index → hex corner indices for the shared edge.
+// For flat-top hexes: corners at 0°,60°,...,300° (CW in screen) and
+// directions: 0=SE-screen,1=NE,2=N,3=NW,4=SW,5=S.
+const DIR_TO_EDGE: [number, number][] = [
+  [0, 1], // dir 0 (East/SE-screen)
+  [5, 0], // dir 1 (NE)
+  [4, 5], // dir 2 (NW/N-screen)
+  [3, 4], // dir 3 (West/NW-screen)
+  [2, 3], // dir 4 (SW)
+  [1, 2], // dir 5 (SE/S-screen)
+];
 
 interface OverviewData {
   onlinePlayers: number;
@@ -39,7 +56,17 @@ interface ContentData {
   world: WorldData;
 }
 
-type TabId = 'overview' | 'accounts' | 'monsters' | 'items' | 'zones' | 'map';
+interface ContentVersion {
+  id: string;
+  name: string;
+  status: 'draft' | 'published';
+  isActive: boolean;
+  createdAt: string;
+  createdFrom: string | null;
+  publishedAt: string | null;
+}
+
+type TabId = 'overview' | 'accounts' | 'monsters' | 'items' | 'zones' | 'map' | 'versions';
 
 interface TabDef {
   id: TabId;
@@ -54,14 +81,32 @@ const TABS: TabDef[] = [
   { id: 'items', label: 'Items', icon: '+' },
   { id: 'zones', label: 'Zones', icon: '#' },
   { id: 'map', label: 'Map', icon: '*' },
+  { id: 'versions', label: 'Versions', icon: 'V' },
 ];
+
+/** Tile types available in the editor dropdown (excludes Void). */
+const EDITABLE_TILE_TYPES = [
+  TileType.Plains,
+  TileType.Forest,
+  TileType.Mountain,
+  TileType.Water,
+  TileType.Town,
+  TileType.Dungeon,
+];
+
+/** Adjacent empty hex position where a new tile can be added. */
+interface AdjacentSlot {
+  col: number;
+  row: number;
+  coord: CubeCoord;
+}
 
 export class AdminApp {
   private container: HTMLElement;
   private activeTab: TabId = 'overview';
   private overview: OverviewData | null = null;
   private accounts: AccountData[] = [];
-  private content: ContentData | null = null;
+  private activeVersionId: string | null = null;
   private mapTiles: HexTile[] = [];
 
   /** World tile definitions for room name lookups. */
@@ -79,6 +124,18 @@ export class AdminApp {
   private resizeHandler: (() => void) | null = null;
   private mouseMoveHandler: ((e: MouseEvent) => void) | null = null;
   private mouseUpHandler: (() => void) | null = null;
+
+  // Version state
+  private versions: ContentVersion[] = [];
+  private selectedVersionId: string | null = null;
+  private versionContent: ContentData | null = null;
+
+  // Map editor state
+  private selectedTile: WorldTileDefinition | null = null;
+  private adjacentSlots: AdjacentSlot[] = [];
+  private saveTimeout: ReturnType<typeof setTimeout> | null = null;
+  private hasDragged = false;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
 
   constructor() {
     this.container = document.getElementById('admin-app')!;
@@ -101,26 +158,22 @@ export class AdminApp {
 
     // Fetch admin data
     try {
-      const [overview, accountsData, contentData] = await Promise.all([
+      const [overview, accountsData, versionsData] = await Promise.all([
         this.fetchAdmin<OverviewData>('/api/admin/overview'),
         this.fetchAdmin<{ accounts: AccountData[] }>('/api/admin/accounts'),
-        this.fetchAdmin<ContentData>('/api/admin/content'),
+        this.fetchAdmin<{ versions: ContentVersion[]; activeVersionId: string | null }>('/api/admin/versions'),
       ]);
 
       this.overview = overview;
       this.accounts = accountsData.accounts;
-      this.content = contentData;
+      this.versions = versionsData.versions;
+      this.activeVersionId = versionsData.activeVersionId ?? null;
 
-      // Build hex grid from content world data
-      const grid = new HexGrid();
-      this.worldTileDefs.clear();
-      for (const tileDef of contentData.world.tiles) {
-        const coord = offsetToCube({ col: tileDef.col, row: tileDef.row });
-        const tile = new HexTile(coord, tileDef.type, tileDef.zone);
-        grid.addTile(tile);
-        this.worldTileDefs.set(`${tileDef.col},${tileDef.row}`, tileDef);
+      // Always view a version — select the active one (or first available)
+      const initialVersionId = this.activeVersionId ?? this.versions[0]?.id ?? null;
+      if (initialVersionId) {
+        await this.selectVersion(initialVersionId);
       }
-      this.mapTiles = grid.getAllTiles();
 
       // Restore last active tab from sessionStorage
       const saved = sessionStorage.getItem('adminTab') as TabId | null;
@@ -158,6 +211,28 @@ export class AdminApp {
     } catch {
       // Silently fail refresh — data stays stale
     }
+  }
+
+  /** Find all empty hex positions adjacent to existing tiles. */
+  private computeAdjacentSlots(): void {
+    const occupied = new Set<string>();
+    for (const tile of this.mapTiles) {
+      const offset = cubeToOffset(tile.coord);
+      occupied.add(`${offset.col},${offset.row}`);
+    }
+
+    const adjacent = new Map<string, AdjacentSlot>();
+    for (const tile of this.mapTiles) {
+      const neighbors = getNeighbors(tile.coord);
+      for (const neighborCoord of neighbors) {
+        const offset = cubeToOffset(neighborCoord);
+        const key = `${offset.col},${offset.row}`;
+        if (!occupied.has(key) && !adjacent.has(key)) {
+          adjacent.set(key, { col: offset.col, row: offset.row, coord: neighborCoord });
+        }
+      }
+    }
+    this.adjacentSlots = Array.from(adjacent.values());
   }
 
   // --- Shell ---
@@ -245,6 +320,11 @@ export class AdminApp {
       case 'map':
         content.innerHTML = this.renderMapSection();
         this.initMapCanvas();
+        this.renderSidebar();
+        break;
+      case 'versions':
+        content.innerHTML = this.renderVersions();
+        this.wireVersionEvents();
         break;
     }
   }
@@ -359,9 +439,10 @@ export class AdminApp {
   }
 
   private renderMonsters(): string {
-    if (!this.content) return '<div class="admin-page-empty">No data</div>';
-    const monsters = Object.values(this.content.monsters);
-    const items = this.content.items;
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return '<div class="admin-page-empty">No data</div>';
+    const monsters = Object.values(displayContent.monsters);
+    const items = displayContent.items;
 
     const rows = monsters.map(m => {
       const drops = m.drops?.map(d => {
@@ -408,8 +489,9 @@ export class AdminApp {
   }
 
   private renderItems(): string {
-    if (!this.content) return '<div class="admin-page-empty">No data</div>';
-    const items = Object.values(this.content.items);
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return '<div class="admin-page-empty">No data</div>';
+    const items = Object.values(displayContent.items);
 
     const rows = items.map(i => {
       const effects: string[] = [];
@@ -454,9 +536,10 @@ export class AdminApp {
   }
 
   private renderZones(): string {
-    if (!this.content) return '<div class="admin-page-empty">No data</div>';
-    const zones = Object.values(this.content.zones);
-    const monsters = this.content.monsters;
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return '<div class="admin-page-empty">No data</div>';
+    const zones = Object.values(displayContent.zones);
+    const monsters = displayContent.monsters;
 
     const rows = zones.map(z => {
       const encounters = z.encounterTable.map(e => {
@@ -492,25 +575,300 @@ export class AdminApp {
     `;
   }
 
-  // --- Map ---
+  // --- Versions ---
 
-  private renderMapSection(): string {
+  private renderVersions(): string {
+    const rows = this.versions.map(v => {
+      const statusBadge = v.isActive
+        ? '<span class="version-badge version-badge-active">Active</span>'
+        : v.status === 'published'
+          ? '<span class="version-badge version-badge-published">Published</span>'
+          : '<span class="version-badge version-badge-draft">Draft</span>';
+
+      const date = new Date(v.createdAt).toLocaleDateString();
+
+      let actions = '';
+      if (v.status === 'draft') {
+        actions = `
+          <button class="admin-btn admin-btn-sm version-action" data-action="edit" data-id="${v.id}">Edit</button>
+          <button class="admin-btn admin-btn-sm version-action" data-action="publish" data-id="${v.id}">Publish</button>
+          <button class="admin-btn admin-btn-sm admin-btn-danger version-action" data-action="delete" data-id="${v.id}">Delete</button>
+        `;
+      } else if (v.isActive) {
+        actions = `
+          <button class="admin-btn admin-btn-sm version-action" data-action="view" data-id="${v.id}">View</button>
+          <button class="admin-btn admin-btn-sm version-action" data-action="create-from" data-id="${v.id}">New Draft</button>
+        `;
+      } else {
+        actions = `
+          <button class="admin-btn admin-btn-sm version-action" data-action="view" data-id="${v.id}">View</button>
+          <button class="admin-btn admin-btn-sm version-action" data-action="deploy" data-id="${v.id}">Deploy</button>
+          <button class="admin-btn admin-btn-sm version-action" data-action="create-from" data-id="${v.id}">New Draft</button>
+          <button class="admin-btn admin-btn-sm admin-btn-danger version-action" data-action="delete" data-id="${v.id}">Delete</button>
+        `;
+      }
+
+      return `
+        <tr>
+          <td>${this.escapeHtml(v.name)}</td>
+          <td>${statusBadge}</td>
+          <td>${date}</td>
+          <td class="version-actions-cell">${actions}</td>
+        </tr>
+      `;
+    }).join('');
+
+    const versionBar = this.renderVersionBar();
+
     return `
-      <div class="admin-page admin-page-map">
+      <div class="admin-page">
         <div class="admin-page-header">
-          <h2>World Map (${this.mapTiles.length} tiles)</h2>
+          <h2>Versions</h2>
+          <button class="admin-btn" id="version-create-new">+ New Draft</button>
         </div>
-        <div class="admin-map-wrap">
-          <div class="admin-map-controls">
-            <button class="admin-btn admin-btn-sm" id="map-zoom-in">+</button>
-            <button class="admin-btn admin-btn-sm" id="map-zoom-out">-</button>
-            <button class="admin-btn admin-btn-sm" id="map-reset">Reset</button>
-            <span id="map-hover-info" class="admin-map-info"></span>
-          </div>
-          <canvas id="admin-map-canvas"></canvas>
+        ${versionBar}
+        <div id="version-status" class="version-status"></div>
+        <div class="admin-table-wrap pixel-panel">
+          <table class="admin-table">
+            <thead>
+              <tr><th>Name</th><th>Status</th><th>Created</th><th>Actions</th></tr>
+            </thead>
+            <tbody>${rows || '<tr><td colspan="4" style="text-align:center;opacity:0.5">No versions yet</td></tr>'}</tbody>
+          </table>
         </div>
       </div>
     `;
+  }
+
+  private renderVersionBar(): string {
+    const version = this.versions.find(v => v.id === this.selectedVersionId);
+    if (!version) return '';
+    const isDraft = version.status === 'draft';
+    const statusLabel = version.isActive
+      ? '<span class="version-badge version-badge-active">Active</span>'
+      : version.status === 'published'
+        ? '<span class="version-badge version-badge-published">Published</span>'
+        : '<span class="version-badge version-badge-draft">Draft</span>';
+    const viewActiveBtn = !version.isActive && this.activeVersionId
+      ? `<button class="admin-btn admin-btn-sm" id="version-bar-view-active">View Active</button>`
+      : '';
+    return `
+      <div class="version-bar${isDraft ? ' version-bar-draft' : ' version-bar-readonly'}">
+        <span>${isDraft ? 'Editing' : 'Viewing'}: <strong>${this.escapeHtml(version.name)}</strong></span>
+        ${statusLabel}
+        ${viewActiveBtn}
+      </div>
+    `;
+  }
+
+  private wireVersionEvents(): void {
+    document.getElementById('version-create-new')?.addEventListener('click', () => {
+      this.createDraftFromActive();
+    });
+
+    document.getElementById('version-bar-view-active')?.addEventListener('click', () => {
+      if (this.activeVersionId) this.selectVersion(this.activeVersionId);
+    });
+
+    document.querySelectorAll('.version-action').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const action = (btn as HTMLElement).dataset.action;
+        const id = (btn as HTMLElement).dataset.id!;
+        switch (action) {
+          case 'edit': this.selectVersion(id); break;
+          case 'view': this.selectVersion(id); break;
+          case 'publish': this.publishVersion(id); break;
+          case 'deploy': this.deployVersionAction(id); break;
+          case 'delete': this.deleteVersion(id); break;
+          case 'create-from': this.createDraftFrom(id); break;
+        }
+      });
+    });
+  }
+
+  private async refreshVersions(): Promise<void> {
+    try {
+      const data = await this.fetchAdmin<{ versions: ContentVersion[]; activeVersionId: string | null }>('/api/admin/versions');
+      this.versions = data.versions;
+      this.activeVersionId = data.activeVersionId ?? null;
+    } catch { /* keep stale */ }
+  }
+
+  private async selectVersion(versionId: string): Promise<void> {
+    this.selectedVersionId = versionId;
+    try {
+      const snapshot = await this.fetchAdmin<ContentData>(`/api/admin/versions/${versionId}/content`);
+      this.versionContent = snapshot;
+    } catch {
+      this.versionContent = null;
+    }
+    // Rebuild map data from the current display content
+    this.rebuildMapDataFromDisplay();
+    this.renderTabContent();
+  }
+
+  private async createDraftFromActive(): Promise<void> {
+    const name = prompt('Draft name:');
+    if (!name) return;
+    try {
+      await fetch('/api/admin/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name, fromVersionId: this.activeVersionId }),
+      });
+      await this.refreshVersions();
+      this.renderTabContent();
+    } catch { /* ignore */ }
+  }
+
+  private async createDraftFrom(fromId: string): Promise<void> {
+    const fromVersion = this.versions.find(v => v.id === fromId);
+    const name = prompt('Draft name:', fromVersion ? `${fromVersion.name} (copy)` : '');
+    if (!name) return;
+    try {
+      await fetch('/api/admin/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name, fromVersionId: fromId }),
+      });
+      await this.refreshVersions();
+      this.renderTabContent();
+    } catch { /* ignore */ }
+  }
+
+  private async publishVersion(id: string): Promise<void> {
+    if (!confirm('Publish this draft? It will become immutable.')) return;
+    try {
+      const res = await fetch(`/api/admin/versions/${id}/publish`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        this.showVersionStatus(data.error || 'Failed to publish', true);
+        return;
+      }
+      await this.refreshVersions();
+      // Stay on the version (now read-only as published)
+      this.renderTabContent();
+    } catch { /* ignore */ }
+  }
+
+  private async deployVersionAction(id: string): Promise<void> {
+    const version = this.versions.find(v => v.id === id);
+    if (!confirm(`Deploy "${version?.name ?? id}" to the live game? Players on removed rooms will be relocated.`)) return;
+    try {
+      const res = await fetch(`/api/admin/versions/${id}/deploy`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        this.showVersionStatus(data.error || 'Failed to deploy', true);
+        return;
+      }
+      await this.refreshVersions();
+      this.showVersionStatus(`Deployed! ${data.relocated ?? 0} parties relocated.`, false);
+      this.renderTabContent();
+    } catch { /* ignore */ }
+  }
+
+  private async deleteVersion(id: string): Promise<void> {
+    if (!confirm('Delete this version?')) return;
+    try {
+      const res = await fetch(`/api/admin/versions/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        this.showVersionStatus(data.error || 'Failed to delete', true);
+        return;
+      }
+      await this.refreshVersions();
+      if (this.selectedVersionId === id && this.activeVersionId) {
+        await this.selectVersion(this.activeVersionId);
+        return; // selectVersion already re-renders
+      }
+      this.renderTabContent();
+    } catch { /* ignore */ }
+  }
+
+  private showVersionStatus(msg: string, isError: boolean): void {
+    const el = document.getElementById('version-status');
+    if (el) {
+      el.textContent = msg;
+      el.className = `version-status ${isError ? 'version-status-error' : 'version-status-success'}`;
+      setTimeout(() => { if (el) { el.textContent = ''; el.className = 'version-status'; } }, 5000);
+    }
+  }
+
+  /** Get display content: always the selected version's content. */
+  private getDisplayContent(): ContentData | null {
+    return this.versionContent;
+  }
+
+  /** Whether the current display is read-only (published version selected). */
+  private isReadOnly(): boolean {
+    const version = this.versions.find(v => v.id === this.selectedVersionId);
+    return !version || version.status !== 'draft';
+  }
+
+  /** Rebuild map data from whichever content is currently displayed. */
+  private rebuildMapDataFromDisplay(): void {
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return;
+
+    this.worldTileDefs.clear();
+    const tiles: HexTile[] = [];
+    for (const tileDef of displayContent.world.tiles) {
+      const coord = offsetToCube({ col: tileDef.col, row: tileDef.row });
+      tiles.push(new HexTile(coord, tileDef.type, tileDef.zone));
+      this.worldTileDefs.set(`${tileDef.col},${tileDef.row}`, tileDef);
+    }
+    this.mapTiles = tiles;
+    this.computeAdjacentSlots();
+  }
+
+  /** Build the ?versionId= query string for API calls when editing a draft. */
+  private versionQueryParam(): string {
+    if (this.selectedVersionId) {
+      const version = this.versions.find(v => v.id === this.selectedVersionId);
+      if (version?.status === 'draft') return `?versionId=${this.selectedVersionId}`;
+    }
+    return '';
+  }
+
+  // --- Map ---
+
+  private renderMapSection(): string {
+    const versionBar = this.renderVersionBar();
+    return `
+      <div class="admin-page admin-page-map">
+        ${versionBar}
+        <div class="admin-map-layout">
+          <div class="admin-map-canvas-area">
+            <div class="admin-map-controls">
+              <span id="map-tile-count" class="admin-map-tile-count">World Map (${this.mapTiles.length} tiles)</span>
+              <button class="admin-btn admin-btn-sm" id="map-zoom-in">+</button>
+              <button class="admin-btn admin-btn-sm" id="map-zoom-out">-</button>
+              <button class="admin-btn admin-btn-sm" id="map-reset">Reset</button>
+              <span id="map-hover-info" class="admin-map-info"></span>
+            </div>
+            <canvas id="admin-map-canvas"></canvas>
+          </div>
+          <div class="admin-map-sidebar" id="admin-map-sidebar"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  /** Update the tile count display in the map header. */
+  private updateMapTileCount(): void {
+    const el = document.getElementById('map-tile-count');
+    if (el) el.textContent = `World Map (${this.mapTiles.length} tiles)`;
   }
 
   private cleanupMapCanvas(): void {
@@ -526,9 +884,18 @@ export class AdminApp {
       window.removeEventListener('mouseup', this.mouseUpHandler);
       this.mouseUpHandler = null;
     }
+    if (this.keydownHandler) {
+      window.removeEventListener('keydown', this.keydownHandler);
+      this.keydownHandler = null;
+    }
+    if (this.saveTimeout) {
+      clearTimeout(this.saveTimeout);
+      this.saveTimeout = null;
+    }
     this.mapCanvas = null;
     this.mapCtx = null;
     this.mapInitialized = false;
+    this.selectedTile = null;
   }
 
   private initMapCanvas(): void {
@@ -542,10 +909,16 @@ export class AdminApp {
       if (!this.mapCanvas) return;
       const wrap = this.mapCanvas.parentElement;
       if (wrap) {
-        this.mapCanvas.width = wrap.clientWidth;
-        this.mapCanvas.height = wrap.clientHeight - 40;
+        // Buffer must match CSS display size to avoid hitbox coordinate mismatch
+        this.mapCanvas.width = this.mapCanvas.clientWidth;
+        this.mapCanvas.height = this.mapCanvas.clientHeight;
         if (!this.mapInitialized) {
-          this.mapOffset = { x: this.mapCanvas.width / 2, y: this.mapCanvas.height / 2 };
+          // Center on start tile
+          const startPixel = this.getStartTilePixel();
+          this.mapOffset = {
+            x: this.mapCanvas.width / 2 - startPixel.x * this.mapZoom,
+            y: this.mapCanvas.height / 2 - startPixel.y * this.mapZoom,
+          };
           this.mapInitialized = true;
         }
         this.drawMap();
@@ -558,20 +931,33 @@ export class AdminApp {
     // Pan (mouse)
     this.mapCanvas.addEventListener('mousedown', (e) => {
       this.isDragging = true;
+      this.hasDragged = false;
       this.dragStart = { x: e.clientX, y: e.clientY };
       this.dragOffsetStart = { ...this.mapOffset };
     });
     this.mouseMoveHandler = (e: MouseEvent) => {
       if (!this.isDragging) return;
+      const dx = e.clientX - this.dragStart.x;
+      const dy = e.clientY - this.dragStart.y;
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+        this.hasDragged = true;
+      }
       this.mapOffset = {
-        x: this.dragOffsetStart.x + (e.clientX - this.dragStart.x),
-        y: this.dragOffsetStart.y + (e.clientY - this.dragStart.y),
+        x: this.dragOffsetStart.x + dx,
+        y: this.dragOffsetStart.y + dy,
       };
       this.drawMap();
     };
     window.addEventListener('mousemove', this.mouseMoveHandler);
     this.mouseUpHandler = () => { this.isDragging = false; };
     window.addEventListener('mouseup', this.mouseUpHandler);
+
+    // Click to select/add tile
+    this.mapCanvas.addEventListener('click', (e) => {
+      if (this.hasDragged) return;
+      const rect = this.mapCanvas!.getBoundingClientRect();
+      this.handleMapClick(e.clientX - rect.left, e.clientY - rect.top);
+    });
 
     // Zoom (wheel)
     this.mapCanvas.addEventListener('wheel', (e) => {
@@ -601,6 +987,25 @@ export class AdminApp {
     });
     this.mapCanvas.addEventListener('touchend', () => { lastTouch = null; });
 
+    // Delete key shortcut (only in edit mode)
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if (this.isReadOnly()) return;
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        const tag = (document.activeElement?.tagName ?? '').toLowerCase();
+        if (tag === 'input' || tag === 'select' || tag === 'textarea') return;
+        if (this.selectedTile) {
+          e.preventDefault();
+          this.deleteSelectedTile();
+        }
+      }
+    };
+    window.addEventListener('keydown', this.keydownHandler);
+
+    // Version bar "View Active" button (if present)
+    document.getElementById('version-bar-view-active')?.addEventListener('click', () => {
+      if (this.activeVersionId) this.selectVersion(this.activeVersionId);
+    });
+
     // Hover info
     this.mapCanvas.addEventListener('mousemove', (e) => {
       if (this.isDragging) return;
@@ -619,12 +1024,31 @@ export class AdminApp {
     });
     document.getElementById('map-reset')?.addEventListener('click', () => {
       this.mapZoom = 1.0;
+      const startPixel = this.getStartTilePixel();
       this.mapOffset = {
-        x: this.mapCanvas!.width / 2,
-        y: this.mapCanvas!.height / 2,
+        x: this.mapCanvas!.width / 2 - startPixel.x * this.mapZoom,
+        y: this.mapCanvas!.height / 2 - startPixel.y * this.mapZoom,
       };
       this.drawMap();
     });
+  }
+
+  /** Helper: draw a hex at (sx, sy) with given scale (1.0 = normal). */
+  private drawHex(ctx: CanvasRenderingContext2D, corners: { x: number; y: number }[], sx: number, sy: number, zoom: number, scale = 1.0): void {
+    ctx.beginPath();
+    for (let i = 0; i < corners.length; i++) {
+      const cx = sx + corners[i].x * zoom * scale;
+      const cy = sy + corners[i].y * zoom * scale;
+      if (i === 0) ctx.moveTo(cx, cy);
+      else ctx.lineTo(cx, cy);
+    }
+    ctx.closePath();
+  }
+
+  /** Helper: test if screen-space coord is within cull bounds. */
+  private inBounds(sx: number, sy: number, canvas: HTMLCanvasElement, zoom: number, pad = 2): boolean {
+    const margin = HEX_SIZE * zoom * pad;
+    return sx > -margin && sx < canvas.width + margin && sy > -margin && sy < canvas.height + margin;
   }
 
   private drawMap(): void {
@@ -641,31 +1065,562 @@ export class AdminApp {
     const ox = this.mapOffset.x;
     const oy = this.mapOffset.y;
 
+    // Build zone lookup: "col,row" → zone string
+    const zoneMap = new Map<string, string>();
     for (const tile of this.mapTiles) {
+      const off = cubeToOffset(tile.coord);
+      zoneMap.set(`${off.col},${off.row}`, tile.zone);
+    }
+
+    const selectedZone = this.selectedTile
+      ? zoneMap.get(`${this.selectedTile.col},${this.selectedTile.row}`) ?? null
+      : null;
+
+    // Partition tiles into selected-zone vs other
+    const otherTiles: HexTile[] = [];
+    const zoneTiles: HexTile[] = [];
+    let selectedHexTile: HexTile | null = null;
+
+    for (const tile of this.mapTiles) {
+      const off = cubeToOffset(tile.coord);
+      const isSelected = this.selectedTile &&
+        this.selectedTile.col === off.col &&
+        this.selectedTile.row === off.row;
+      if (isSelected) {
+        selectedHexTile = tile;
+      } else if (selectedZone && tile.zone === selectedZone) {
+        zoneTiles.push(tile);
+      } else {
+        otherTiles.push(tile);
+      }
+    }
+
+    // --- Layer 1: Adjacent slots (hidden in read-only mode) ---
+    const showSlots = !this.isReadOnly();
+    for (const slot of (showSlots ? this.adjacentSlots : [])) {
+      const pixel = cubeToPixel(slot.coord);
+      const sx = pixel.x * zoom + ox;
+      const sy = pixel.y * zoom + oy;
+      if (!this.inBounds(sx, sy, canvas, zoom)) continue;
+
+      this.drawHex(ctx, corners, sx, sy, zoom);
+
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.04)';
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Draw + icon
+      const plusSize = 14 * zoom;
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.35)';
+      ctx.lineWidth = Math.max(1.5, 3 * zoom);
+      ctx.beginPath();
+      ctx.moveTo(sx - plusSize, sy);
+      ctx.lineTo(sx + plusSize, sy);
+      ctx.moveTo(sx, sy - plusSize);
+      ctx.lineTo(sx, sy + plusSize);
+      ctx.stroke();
+    }
+
+    // --- Layer 2: Tiles NOT in the selected zone ---
+    for (const tile of otherTiles) {
       const pixel = cubeToPixel(tile.coord);
       const sx = pixel.x * zoom + ox;
       const sy = pixel.y * zoom + oy;
+      if (!this.inBounds(sx, sy, canvas, zoom)) continue;
 
-      // Cull tiles outside viewport
-      if (sx < -HEX_SIZE * zoom * 2 || sx > canvas.width + HEX_SIZE * zoom * 2) continue;
-      if (sy < -HEX_SIZE * zoom * 2 || sy > canvas.height + HEX_SIZE * zoom * 2) continue;
-
-      ctx.beginPath();
-      for (let i = 0; i < corners.length; i++) {
-        const cx = sx + corners[i].x * zoom;
-        const cy = sy + corners[i].y * zoom;
-        if (i === 0) ctx.moveTo(cx, cy);
-        else ctx.lineTo(cx, cy);
-      }
-      ctx.closePath();
+      this.drawHex(ctx, corners, sx, sy, zoom);
 
       const color = TILE_CONFIGS[tile.type]?.color ?? 0x333333;
       ctx.fillStyle = '#' + color.toString(16).padStart(6, '0');
       ctx.fill();
-
       ctx.strokeStyle = '#2a2a3e';
       ctx.lineWidth = 0.5;
       ctx.stroke();
+
+      this.drawStartMarker(ctx, tile, sx, sy, zoom);
+    }
+
+    // --- Layer 3: Glow for selected zone boundary (multi-pass for gradient falloff) ---
+    if (selectedZone) {
+      const allZoneTiles = selectedHexTile ? [...zoneTiles, selectedHexTile] : zoneTiles;
+
+      // Collect boundary edges once
+      const edges: { x0: number; y0: number; x1: number; y1: number }[] = [];
+      for (const tile of allZoneTiles) {
+        const pixel = cubeToPixel(tile.coord);
+        const sx = pixel.x * zoom + ox;
+        const sy = pixel.y * zoom + oy;
+        if (!this.inBounds(sx, sy, canvas, zoom, 4)) continue;
+
+        for (let dir = 0; dir < 6; dir++) {
+          const neighbor = getNeighbor(tile.coord, dir);
+          const nOff = cubeToOffset(neighbor);
+          const nZone = zoneMap.get(`${nOff.col},${nOff.row}`);
+          if (nZone === selectedZone) continue;
+
+          const [ei0, ei1] = DIR_TO_EDGE[dir];
+          edges.push({
+            x0: sx + corners[ei0].x * zoom,
+            y0: sy + corners[ei0].y * zoom,
+            x1: sx + corners[ei1].x * zoom,
+            y1: sy + corners[ei1].y * zoom,
+          });
+        }
+      }
+
+      // Draw multiple passes: wide & faint → narrow & bright
+      ctx.save();
+      ctx.lineCap = 'round';
+      const passes = [
+        { width: Math.max(20, 40 * zoom), alpha: 0.04 },
+        { width: Math.max(14, 28 * zoom), alpha: 0.08 },
+        { width: Math.max(8, 16 * zoom), alpha: 0.15 },
+        { width: Math.max(4, 8 * zoom), alpha: 0.25 },
+        { width: Math.max(2, 4 * zoom), alpha: 0.4 },
+      ];
+      for (const pass of passes) {
+        ctx.strokeStyle = `rgba(255, 255, 255, ${pass.alpha})`;
+        ctx.lineWidth = pass.width;
+        ctx.beginPath();
+        for (const e of edges) {
+          ctx.moveTo(e.x0, e.y0);
+          ctx.lineTo(e.x1, e.y1);
+        }
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+
+    // --- Layer 4: Tiles IN the selected zone (covers inner shadow) ---
+    for (const tile of zoneTiles) {
+      const pixel = cubeToPixel(tile.coord);
+      const sx = pixel.x * zoom + ox;
+      const sy = pixel.y * zoom + oy;
+      if (!this.inBounds(sx, sy, canvas, zoom)) continue;
+
+      this.drawHex(ctx, corners, sx, sy, zoom);
+
+      const color = TILE_CONFIGS[tile.type]?.color ?? 0x333333;
+      ctx.fillStyle = '#' + color.toString(16).padStart(6, '0');
+      ctx.fill();
+      ctx.strokeStyle = '#2a2a3e';
+      ctx.lineWidth = 0.5;
+      ctx.stroke();
+
+      this.drawStartMarker(ctx, tile, sx, sy, zoom);
+    }
+
+    // --- Layer 5: Yellow borders on zone-to-zone boundaries only ---
+    ctx.save();
+    ctx.strokeStyle = '#ffc845';
+    ctx.lineWidth = Math.max(1.5, 2.5 * zoom);
+    ctx.lineCap = 'round';
+
+    for (const tile of this.mapTiles) {
+      const pixel = cubeToPixel(tile.coord);
+      const sx = pixel.x * zoom + ox;
+      const sy = pixel.y * zoom + oy;
+      if (!this.inBounds(sx, sy, canvas, zoom, 3)) continue;
+
+      const tileZone = tile.zone;
+      for (let dir = 0; dir < 6; dir++) {
+        const neighbor = getNeighbor(tile.coord, dir);
+        const nOff = cubeToOffset(neighbor);
+        const nZone = zoneMap.get(`${nOff.col},${nOff.row}`);
+        // Only where neighbor tile exists AND is a different zone
+        if (nZone === undefined || nZone === tileZone) continue;
+
+        const [ei0, ei1] = DIR_TO_EDGE[dir];
+        ctx.beginPath();
+        ctx.moveTo(sx + corners[ei0].x * zoom, sy + corners[ei0].y * zoom);
+        ctx.lineTo(sx + corners[ei1].x * zoom, sy + corners[ei1].y * zoom);
+        ctx.stroke();
+      }
+    }
+    ctx.restore();
+
+    // --- Layer 6: Selected tile (drawn last, enlarged to "pop up") ---
+    if (selectedHexTile) {
+      const pixel = cubeToPixel(selectedHexTile.coord);
+      const sx = pixel.x * zoom + ox;
+      const sy = pixel.y * zoom + oy;
+
+      // Shadow under the popped tile
+      ctx.save();
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
+      ctx.shadowBlur = Math.max(4, 8 * zoom);
+      ctx.shadowOffsetY = Math.max(1, 3 * zoom);
+      this.drawHex(ctx, corners, sx, sy, zoom, 1.08);
+      const color = TILE_CONFIGS[selectedHexTile.type]?.color ?? 0x333333;
+      ctx.fillStyle = '#' + color.toString(16).padStart(6, '0');
+      ctx.fill();
+      ctx.restore();
+
+      // Subtle outline + yellow only on zone-boundary edges
+      const tileZone = selectedHexTile.zone;
+      this.drawHex(ctx, corners, sx, sy, zoom, 1.08);
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.25)';
+      ctx.lineWidth = Math.max(1, 1.5 * zoom);
+      ctx.stroke();
+
+      // Draw yellow on edges that border a different zone
+      const scale = 1.08;
+      ctx.strokeStyle = '#ffc845';
+      ctx.lineWidth = Math.max(2, 3 * zoom);
+      ctx.lineCap = 'round';
+      for (let dir = 0; dir < 6; dir++) {
+        const neighbor = getNeighbor(selectedHexTile.coord, dir);
+        const nOff = cubeToOffset(neighbor);
+        const nZone = zoneMap.get(`${nOff.col},${nOff.row}`);
+        if (nZone === undefined || nZone === tileZone) continue;
+        const [ei0, ei1] = DIR_TO_EDGE[dir];
+        ctx.beginPath();
+        ctx.moveTo(sx + corners[ei0].x * zoom * scale, sy + corners[ei0].y * zoom * scale);
+        ctx.lineTo(sx + corners[ei1].x * zoom * scale, sy + corners[ei1].y * zoom * scale);
+        ctx.stroke();
+      }
+
+      this.drawStartMarker(ctx, selectedHexTile, sx, sy, zoom);
+    }
+  }
+
+  /** Draw the star marker if this tile is the start tile. */
+  private drawStartMarker(ctx: CanvasRenderingContext2D, tile: HexTile, sx: number, sy: number, zoom: number): void {
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return;
+    const offset = cubeToOffset(tile.coord);
+    if (displayContent.world.startTile.col === offset.col &&
+        displayContent.world.startTile.row === offset.row) {
+      ctx.save();
+      ctx.font = `${Math.max(10, 16 * zoom)}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = '#ffc845';
+      ctx.fillText('\u2605', sx, sy);
+      ctx.restore();
+    }
+  }
+
+  /** Hit-test a click on the canvas and select or create a tile. */
+  private handleMapClick(mx: number, my: number): void {
+    const zoom = this.mapZoom;
+    const worldX = (mx - this.mapOffset.x) / zoom;
+    const worldY = (my - this.mapOffset.y) / zoom;
+
+    // Use proper hex rounding to find which hex was clicked
+    const clickedCube = pixelToCube({ x: worldX, y: worldY });
+    const clickedOffset = cubeToOffset(clickedCube);
+    const clickedKey = `${clickedOffset.col},${clickedOffset.row}`;
+
+    // Check existing tiles first
+    const tileDef = this.worldTileDefs.get(clickedKey);
+    if (tileDef) {
+      this.selectedTile = tileDef;
+      this.drawMap();
+      this.renderSidebar();
+      return;
+    }
+
+    // Check adjacent slots (only allow adding in editable mode)
+    if (!this.isReadOnly()) {
+      const clickedSlot = this.adjacentSlots.find(s =>
+        cubeEquals(s.coord, clickedCube)
+      );
+      if (clickedSlot) {
+        this.addTileAtSlot(clickedSlot);
+        return;
+      }
+    }
+
+    // Clicked empty space — deselect
+    this.selectedTile = null;
+    this.drawMap();
+    this.renderSidebar();
+  }
+
+  /** Create a new tile at an adjacent slot with defaults. */
+  private async addTileAtSlot(slot: AdjacentSlot): Promise<void> {
+    if (this.isReadOnly()) return;
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return;
+
+    // Default zone: prefer the currently selected tile's zone if it's a neighbor,
+    // otherwise inherit from the first neighboring tile
+    const neighbors = getNeighbors(slot.coord);
+    const selectedZone = this.selectedTile?.zone;
+    let defaultZone = 'unknown';
+    let fallbackZone = 'unknown';
+    for (const neighborCoord of neighbors) {
+      const offset = cubeToOffset(neighborCoord);
+      const neighborDef = this.worldTileDefs.get(`${offset.col},${offset.row}`);
+      if (neighborDef) {
+        if (fallbackZone === 'unknown') fallbackZone = neighborDef.zone;
+        if (selectedZone && neighborDef.zone === selectedZone) {
+          defaultZone = selectedZone;
+          break;
+        }
+      }
+    }
+    if (defaultZone === 'unknown') defaultZone = fallbackZone;
+
+    const newTile: WorldTileDefinition = {
+      col: slot.col,
+      row: slot.row,
+      type: TileType.Plains,
+      zone: defaultZone,
+      name: 'Default Room Name',
+    };
+
+    try {
+      const qp = this.versionQueryParam();
+      const res = await fetch(`/api/admin/world/tile${qp}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(newTile),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        this.showSidebarError(data.error || 'Failed to add tile');
+        return;
+      }
+      this.updateDisplayWorld(data.world);
+      this.selectedTile = newTile;
+      this.drawMap();
+      this.updateMapTileCount();
+      this.renderSidebar(true);
+    } catch {
+      this.showSidebarError('Network error — could not add tile');
+    }
+  }
+
+  /** Save the currently selected tile to the server (debounced). */
+  private scheduleSave(): void {
+    if (this.saveTimeout) clearTimeout(this.saveTimeout);
+    this.saveTimeout = setTimeout(() => this.saveSelectedTile(), 300);
+  }
+
+  private async saveSelectedTile(): Promise<void> {
+    if (!this.selectedTile) return;
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return;
+
+    try {
+      const qp = this.versionQueryParam();
+      const res = await fetch(`/api/admin/world/tile${qp}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(this.selectedTile),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        this.showSidebarError(data.error || 'Failed to save tile');
+        return;
+      }
+      this.updateDisplayWorld(data.world);
+      // Re-select the tile from the updated data
+      this.selectedTile = this.worldTileDefs.get(
+        `${this.selectedTile.col},${this.selectedTile.row}`
+      ) ?? null;
+      this.drawMap();
+    } catch {
+      this.showSidebarError('Network error — could not save tile');
+    }
+  }
+
+  /** Delete the currently selected tile. */
+  private async deleteSelectedTile(): Promise<void> {
+    if (!this.selectedTile) return;
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return;
+
+    try {
+      const qp = this.versionQueryParam();
+      const res = await fetch(`/api/admin/world/tile${qp}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ col: this.selectedTile.col, row: this.selectedTile.row }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        this.showSidebarError(data.error || 'Failed to delete tile');
+        return;
+      }
+      this.updateDisplayWorld(data.world);
+      this.selectedTile = null;
+      this.drawMap();
+      this.updateMapTileCount();
+      this.renderSidebar();
+    } catch {
+      this.showSidebarError('Network error — could not delete tile');
+    }
+  }
+
+  /** Set the currently selected tile as the start tile. */
+  private async setAsStartTile(): Promise<void> {
+    if (!this.selectedTile) return;
+    const displayContent = this.getDisplayContent();
+    if (!displayContent) return;
+
+    try {
+      const qp = this.versionQueryParam();
+      const res = await fetch(`/api/admin/world/start-tile${qp}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ col: this.selectedTile.col, row: this.selectedTile.row }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        this.showSidebarError(data.error || 'Failed to set start tile');
+        return;
+      }
+      this.updateDisplayWorld(data.world);
+      this.drawMap();
+      this.renderSidebar();
+    } catch {
+      this.showSidebarError('Network error — could not set start tile');
+    }
+  }
+
+  /** Update the world data on the currently displayed version, then rebuild. */
+  private updateDisplayWorld(world: WorldData): void {
+    if (this.versionContent) {
+      this.versionContent.world = world;
+    }
+    this.rebuildMapDataFromDisplay();
+  }
+
+  // --- Sidebar ---
+
+  private renderSidebar(focusName = false): void {
+    const sidebar = document.getElementById('admin-map-sidebar');
+    if (!sidebar) return;
+
+    const readOnly = this.isReadOnly();
+
+    if (!this.selectedTile) {
+      const hint = readOnly
+        ? 'Click a room to view details. This version is read-only.'
+        : 'Click a room to edit, or click + to add a new room.';
+      sidebar.innerHTML = `
+        <div class="admin-map-sidebar-header">Room Editor</div>
+        <div class="admin-map-sidebar-placeholder">${hint}</div>
+      `;
+      return;
+    }
+
+    const tile = this.selectedTile;
+    const displayContent = this.getDisplayContent();
+    const zones = displayContent ? Object.values(displayContent.zones) : [];
+    const startTile = displayContent?.world.startTile;
+    const isStart = startTile && startTile.col === tile.col && startTile.row === tile.row;
+    const isTraversable = TILE_CONFIGS[tile.type]?.traversable ?? false;
+    const disabled = readOnly ? ' disabled' : '';
+
+    const typeOptions = EDITABLE_TILE_TYPES.map(t =>
+      `<option value="${t}"${t === tile.type ? ' selected' : ''}>${t.charAt(0).toUpperCase() + t.slice(1)}</option>`
+    ).join('');
+
+    const zoneOptions = zones.map(z =>
+      `<option value="${z.id}"${z.id === tile.zone ? ' selected' : ''}>${z.displayName}</option>`
+    ).join('');
+
+    let startBtnHtml = '';
+    if (!readOnly) {
+      startBtnHtml = isStart
+        ? `<div class="admin-map-sidebar-start-badge">\u2605 Start Tile</div>`
+        : isTraversable
+          ? `<button class="admin-btn admin-map-start-btn" id="sidebar-set-start">Set as Start Tile</button>`
+          : '';
+    } else if (isStart) {
+      startBtnHtml = `<div class="admin-map-sidebar-start-badge">\u2605 Start Tile</div>`;
+    }
+
+    const deleteBtnHtml = readOnly ? '' : (isStart
+      ? `<button class="admin-btn admin-map-delete-btn" disabled title="Cannot delete the start tile">Delete Room</button>
+         <div class="admin-map-sidebar-hint">Assign a different start tile before deleting.</div>`
+      : `<button class="admin-btn admin-map-delete-btn" id="sidebar-delete">Delete Room</button>`);
+
+    sidebar.innerHTML = `
+      <div class="admin-map-sidebar-header">Room ${readOnly ? 'Info' : 'Editor'}</div>
+      <div class="admin-map-sidebar-fields">
+        <div class="admin-map-sidebar-field">
+          <label>Room Name</label>
+          <input type="text" id="sidebar-name" value="${this.escapeHtml(tile.name)}"${disabled} />
+        </div>
+        <div class="admin-map-sidebar-field">
+          <label>Type</label>
+          <select id="sidebar-type"${disabled}>${typeOptions}</select>
+        </div>
+        <div class="admin-map-sidebar-field">
+          <label>Zone</label>
+          <select id="sidebar-zone"${disabled}>${zoneOptions}</select>
+        </div>
+        <div class="admin-map-sidebar-field">
+          <label>Coordinates</label>
+          <div class="admin-map-sidebar-coords">(${tile.col}, ${tile.row})</div>
+        </div>
+        ${startBtnHtml}
+        <div class="admin-map-sidebar-spacer"></div>
+        ${deleteBtnHtml}
+        <div id="sidebar-error" class="admin-map-sidebar-error"></div>
+      </div>
+    `;
+
+    // Wire events
+    const nameInput = document.getElementById('sidebar-name') as HTMLInputElement;
+    const typeSelect = document.getElementById('sidebar-type') as HTMLSelectElement;
+    const zoneSelect = document.getElementById('sidebar-zone') as HTMLSelectElement;
+
+    nameInput?.addEventListener('input', () => {
+      if (this.selectedTile) {
+        this.selectedTile.name = nameInput.value;
+        this.scheduleSave();
+      }
+    });
+
+    typeSelect?.addEventListener('change', () => {
+      if (this.selectedTile) {
+        this.selectedTile.type = typeSelect.value as TileType;
+        this.scheduleSave();
+        // Re-render sidebar to update start tile button visibility
+        this.renderSidebar();
+      }
+    });
+
+    zoneSelect?.addEventListener('change', () => {
+      if (this.selectedTile) {
+        this.selectedTile.zone = zoneSelect.value;
+        this.scheduleSave();
+      }
+    });
+
+    document.getElementById('sidebar-set-start')?.addEventListener('click', () => {
+      this.setAsStartTile();
+    });
+
+    document.getElementById('sidebar-delete')?.addEventListener('click', () => {
+      this.deleteSelectedTile();
+    });
+
+    if (focusName && nameInput) {
+      nameInput.focus();
+      nameInput.select();
+    }
+  }
+
+  private showSidebarError(message: string): void {
+    const errorEl = document.getElementById('sidebar-error');
+    if (errorEl) {
+      errorEl.textContent = message;
+      setTimeout(() => { if (errorEl) errorEl.textContent = ''; }, 5000);
     }
   }
 
@@ -677,26 +1632,38 @@ export class AdminApp {
     const worldX = (mx - this.mapOffset.x) / zoom;
     const worldY = (my - this.mapOffset.y) / zoom;
 
-    let closest: HexTile | null = null;
-    let closestDist = Infinity;
-    for (const tile of this.mapTiles) {
-      const pixel = cubeToPixel(tile.coord);
-      const dx = pixel.x - worldX;
-      const dy = pixel.y - worldY;
-      const dist = dx * dx + dy * dy;
-      if (dist < closestDist && dist < HEX_SIZE * HEX_SIZE) {
-        closestDist = dist;
-        closest = tile;
-      }
+    const hoveredCube = pixelToCube({ x: worldX, y: worldY });
+    const hoveredOffset = cubeToOffset(hoveredCube);
+    const hoveredKey = `${hoveredOffset.col},${hoveredOffset.row}`;
+
+    // Check existing tiles
+    const tileDef = this.worldTileDefs.get(hoveredKey);
+    if (tileDef) {
+      infoEl.textContent = `${tileDef.type} (${hoveredOffset.col}, ${hoveredOffset.row}) — ${tileDef.zone} — ${tileDef.name}`;
+      return;
     }
 
-    if (closest) {
-      const offset = cubeToOffset(closest.coord);
-      const tileDef = this.worldTileDefs.get(`${offset.col},${offset.row}`);
-      const roomName = tileDef?.name ? ` — ${tileDef.name}` : '';
-      infoEl.textContent = `${closest.type} (${offset.col}, ${offset.row}) — ${closest.zone}${roomName}`;
+    // Check adjacent slots
+    const slot = this.adjacentSlots.find(s => cubeEquals(s.coord, hoveredCube));
+    if (slot) {
+      infoEl.textContent = `+ New room (${slot.col}, ${slot.row})`;
     } else {
       infoEl.textContent = '';
     }
+  }
+
+  /** Get the pixel position of the start tile (or world origin if none). */
+  private getStartTilePixel(): { x: number; y: number } {
+    const displayContent = this.getDisplayContent();
+    if (displayContent) {
+      const { col, row } = displayContent.world.startTile;
+      const coord = offsetToCube({ col, row });
+      return cubeToPixel(coord);
+    }
+    return { x: 0, y: 0 };
+  }
+
+  private escapeHtml(str: string): string {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 }

--- a/client/src/network/GameClient.ts
+++ b/client/src/network/GameClient.ts
@@ -6,6 +6,7 @@ type StateListener = (state: ServerStateMessage) => void;
 type ChatListener = (message: ChatMessage) => void;
 type ChatHistoryListener = (channelType: ChatChannelType, channelId: string, messages: ChatMessage[]) => void;
 type ConnectionListener = (connected: boolean) => void;
+type WorldUpdateListener = () => void;
 
 export class GameClient {
   private ws: WebSocket | null = null;
@@ -18,6 +19,7 @@ export class GameClient {
   private connectionListeners = new Set<ConnectionListener>();
   private chatListeners = new Set<ChatListener>();
   private chatHistoryListeners = new Set<ChatHistoryListener>();
+  private worldUpdateListeners = new Set<WorldUpdateListener>();
 
   /** Pending connect resolve — set during connect() call. */
   private connectResolve?: (result: { success: boolean; error?: string }) => void;
@@ -120,6 +122,10 @@ export class GameClient {
         } else if (msg.type === 'chat_history') {
           for (const listener of this.chatHistoryListeners) {
             listener(msg.channelType, msg.channelId, msg.messages);
+          }
+        } else if (msg.type === 'world_update') {
+          for (const listener of this.worldUpdateListeners) {
+            listener();
           }
         } else if (msg.type === 'error') {
           console.warn('[GameClient] server error:', msg.message);
@@ -302,6 +308,12 @@ export class GameClient {
     return () => { this.chatHistoryListeners.delete(listener); };
   }
 
+  /** Subscribe to world update notifications. Returns an unsubscribe function. */
+  onWorldUpdate(listener: WorldUpdateListener): () => void {
+    this.worldUpdateListeners.add(listener);
+    return () => { this.worldUpdateListeners.delete(listener); };
+  }
+
   destroy(): void {
     this.destroyed = true;
     if (this.reconnectTimer) {
@@ -313,5 +325,6 @@ export class GameClient {
     this.connectionListeners.clear();
     this.chatListeners.clear();
     this.chatHistoryListeners.clear();
+    this.worldUpdateListeners.clear();
   }
 }

--- a/client/src/scenes/WorldMapScene.ts
+++ b/client/src/scenes/WorldMapScene.ts
@@ -214,6 +214,12 @@ export class WorldMapScene extends Phaser.Scene {
 
   // ── Grid Building ─────────────────────────────────────────
 
+  /** Rebuild the grid from updated WorldCache data and re-render. */
+  rebuildFromCache(): void {
+    this.grid = this.buildGridFromCache();
+    this.renderGrid();
+  }
+
   private buildGridFromCache(): HexGrid {
     const grid = new HexGrid();
     this.worldTileDefs.clear();

--- a/client/src/screens/MapScreen.ts
+++ b/client/src/screens/MapScreen.ts
@@ -27,6 +27,19 @@ export class MapScreen implements Screen {
     this.onChatCallback = cb;
   }
 
+  /** Refresh the map from updated WorldCache data. */
+  refreshWorld(): void {
+    const scene = this.getScene();
+    if (scene) {
+      scene.rebuildFromCache();
+      // Re-apply current state (party position, other players, etc.)
+      if (this.gameClient.lastState) {
+        scene.applyServerState(this.gameClient.lastState, true);
+      }
+    }
+    // If scene doesn't exist yet, next createPhaserGame() will build from current cache
+  }
+
   /** Check if the current player can move (must be owner or leader). */
   private canMove(): boolean {
     const state = this.gameClient.lastState;

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -2098,12 +2098,19 @@ html, body {
 }
 
 /* Map */
-.admin-map-wrap {
+.admin-map-layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
+.admin-map-canvas-area {
   flex: 1;
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  padding: 0 24px 24px;
+  min-width: 0;
+  padding: 0 12px 12px 24px;
 }
 
 .admin-map-controls {
@@ -2112,6 +2119,12 @@ html, body {
   align-items: center;
   padding: 12px 0;
   flex-shrink: 0;
+}
+
+.admin-map-tile-count {
+  font-size: 9px;
+  color: var(--text-primary);
+  margin-right: 8px;
 }
 
 .admin-map-info {
@@ -2130,6 +2143,127 @@ html, body {
 
 #admin-map-canvas:active {
   cursor: grabbing;
+}
+
+/* Map sidebar (tile editor) */
+.admin-map-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  background: var(--bg-panel);
+  border-left: 2px solid var(--border-pixel);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.admin-map-sidebar-header {
+  font-size: 10px;
+  color: var(--accent-gold);
+  padding: 14px 14px 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border-bottom: 1px solid var(--border-pixel);
+}
+
+.admin-map-sidebar-placeholder {
+  font-size: 8px;
+  color: var(--text-dim);
+  padding: 24px 14px;
+  line-height: 2;
+  text-align: center;
+}
+
+.admin-map-sidebar-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  flex: 1;
+}
+
+.admin-map-sidebar-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.admin-map-sidebar-field label {
+  font-size: 7px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.admin-map-sidebar-field input,
+.admin-map-sidebar-field select {
+  font-family: var(--pixel-font);
+  font-size: 9px;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-pixel);
+  outline: none;
+}
+
+.admin-map-sidebar-field input:focus,
+.admin-map-sidebar-field select:focus {
+  border-color: var(--accent-gold);
+}
+
+.admin-map-sidebar-coords {
+  font-size: 9px;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
+.admin-map-sidebar-spacer {
+  flex: 1;
+  min-height: 16px;
+}
+
+.admin-map-start-btn {
+  font-size: 8px;
+  padding: 6px 10px;
+  color: var(--accent-gold);
+  border-color: var(--accent-gold);
+}
+
+.admin-map-start-btn:hover {
+  background: rgba(255, 200, 69, 0.1);
+}
+
+.admin-map-sidebar-start-badge {
+  font-size: 9px;
+  color: var(--accent-gold);
+  padding: 6px 0;
+}
+
+.admin-map-delete-btn {
+  font-size: 8px;
+  padding: 6px 10px;
+  color: var(--accent-red);
+  border-color: var(--accent-red);
+}
+
+.admin-map-delete-btn:hover:not(:disabled) {
+  background: rgba(255, 82, 82, 0.1);
+}
+
+.admin-map-delete-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.admin-map-sidebar-hint {
+  font-size: 7px;
+  color: var(--text-dim);
+  line-height: 1.6;
+}
+
+.admin-map-sidebar-error {
+  font-size: 8px;
+  color: var(--accent-red);
+  min-height: 16px;
 }
 
 /* ── Desktop Font Scaling ────────────────────────────────── */
@@ -2160,4 +2294,97 @@ html, body {
   .social-search { font-size: 10px; }
   .social-user-name { font-size: 10px; }
   .social-action-btn { font-size: 8px; }
+}
+
+/* === Version System === */
+
+.version-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.version-badge-draft {
+  background: #1e3a5f;
+  color: #6db3f2;
+}
+
+.version-badge-published {
+  background: #1e4d2b;
+  color: #6fdc8c;
+}
+
+.version-badge-active {
+  background: #4d3600;
+  color: #ffc845;
+}
+
+.version-actions-cell {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.admin-btn-danger {
+  background: #3d1111;
+  color: #f87171;
+  border-color: #5a1e1e;
+}
+
+.admin-btn-danger:hover {
+  background: #5a1e1e;
+}
+
+.version-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+.version-bar-draft {
+  background: #1e3a5f;
+  border: 1px solid #2a5a8f;
+  color: #6db3f2;
+}
+
+.version-bar-readonly {
+  background: #1e4d2b;
+  border: 1px solid #2a6f3f;
+  color: #6fdc8c;
+}
+
+.version-readonly-label {
+  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.version-status {
+  font-size: 11px;
+  padding: 0 4px;
+  min-height: 20px;
+}
+
+.version-status-error {
+  color: #f87171;
+}
+
+.version-status-success {
+  color: #6fdc8c;
+}
+
+.admin-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -2,15 +2,19 @@ import { Router } from 'express';
 import type { PlayerManager } from '../game/PlayerManager.js';
 import type { AccountStore } from '../auth/AccountStore.js';
 import type { ContentStore } from '../game/ContentStore.js';
+import type { VersionStore } from '../game/VersionStore.js';
 import { adminMiddleware } from './adminMiddleware.js';
 
 interface AdminRouteOptions {
   playerManager: () => PlayerManager;
   accountStore: AccountStore;
   contentStore: () => ContentStore;
+  versionStore: () => VersionStore;
+  rebuildGrid: () => number;
+  deployVersion: (versionId: string) => Promise<{ success: boolean; error?: string; relocated?: number }>;
 }
 
-export function createAdminRoutes({ playerManager: getPlayerManager, accountStore, contentStore: getContentStore }: AdminRouteOptions): Router {
+export function createAdminRoutes({ playerManager: getPlayerManager, accountStore, contentStore: getContentStore, versionStore: getVersionStore, rebuildGrid, deployVersion }: AdminRouteOptions): Router {
   const router = Router();
   router.use(adminMiddleware);
 
@@ -48,6 +52,205 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
       zones: content.getAllZones(),
       world: content.getWorld(),
     });
+  });
+
+  /** Add or update a world tile. Supports ?versionId= for draft editing. */
+  router.put('/world/tile', async (req, res) => {
+    const versionId = req.query.versionId as string | undefined;
+    const { col, row, type, zone, name } = req.body;
+    if (col == null || row == null || !type || !zone || !name) {
+      res.status(400).json({ error: 'Missing required fields: col, row, type, zone, name' });
+      return;
+    }
+
+    if (versionId) {
+      const versions = getVersionStore();
+      const version = versions.get(versionId);
+      if (!version) { res.status(404).json({ error: 'Version not found.' }); return; }
+      if (version.status !== 'draft') { res.status(400).json({ error: 'Only drafts can be edited.' }); return; }
+      const snapshot = await versions.loadSnapshot(versionId);
+      const idx = snapshot.world.tiles.findIndex(t => t.col === col && t.row === row);
+      if (idx >= 0) {
+        snapshot.world.tiles[idx] = { col, row, type, zone, name };
+      } else {
+        snapshot.world.tiles.push({ col, row, type, zone, name });
+      }
+      await versions.saveSnapshot(versionId, snapshot);
+      res.json({ success: true, world: snapshot.world });
+    } else {
+      const content = getContentStore();
+      await content.addOrUpdateTile({ col, row, type, zone, name });
+      const relocated = rebuildGrid();
+      res.json({ success: true, world: content.getWorld(), relocated });
+    }
+  });
+
+  /** Delete a world tile. Supports ?versionId= for draft editing. */
+  router.delete('/world/tile', async (req, res) => {
+    const versionId = req.query.versionId as string | undefined;
+    const { col, row } = req.body;
+    if (col == null || row == null) {
+      res.status(400).json({ error: 'Missing required fields: col, row' });
+      return;
+    }
+
+    if (versionId) {
+      const versions = getVersionStore();
+      const version = versions.get(versionId);
+      if (!version) { res.status(404).json({ error: 'Version not found.' }); return; }
+      if (version.status !== 'draft') { res.status(400).json({ error: 'Only drafts can be edited.' }); return; }
+      const snapshot = await versions.loadSnapshot(versionId);
+      const { startTile } = snapshot.world;
+      if (startTile.col === col && startTile.row === row) {
+        res.status(400).json({ error: 'Cannot delete the start tile.' });
+        return;
+      }
+      const idx = snapshot.world.tiles.findIndex(t => t.col === col && t.row === row);
+      if (idx < 0) { res.status(400).json({ error: 'Tile not found.' }); return; }
+      snapshot.world.tiles.splice(idx, 1);
+      await versions.saveSnapshot(versionId, snapshot);
+      res.json({ success: true, world: snapshot.world });
+    } else {
+      const content = getContentStore();
+      const result = await content.deleteTile(col, row);
+      if (!result.success) {
+        res.status(400).json({ error: result.error });
+        return;
+      }
+      const relocated = rebuildGrid();
+      res.json({ success: true, world: content.getWorld(), relocated });
+    }
+  });
+
+  /** Set the start tile. Supports ?versionId= for draft editing. */
+  router.put('/world/start-tile', async (req, res) => {
+    const versionId = req.query.versionId as string | undefined;
+    const { col, row } = req.body;
+    if (col == null || row == null) {
+      res.status(400).json({ error: 'Missing required fields: col, row' });
+      return;
+    }
+
+    if (versionId) {
+      const versions = getVersionStore();
+      const version = versions.get(versionId);
+      if (!version) { res.status(404).json({ error: 'Version not found.' }); return; }
+      if (version.status !== 'draft') { res.status(400).json({ error: 'Only drafts can be edited.' }); return; }
+      const snapshot = await versions.loadSnapshot(versionId);
+      const tile = snapshot.world.tiles.find(t => t.col === col && t.row === row);
+      if (!tile) { res.status(400).json({ error: 'Tile not found.' }); return; }
+      snapshot.world.startTile = { col, row };
+      await versions.saveSnapshot(versionId, snapshot);
+      res.json({ success: true, world: snapshot.world });
+    } else {
+      const content = getContentStore();
+      const result = await content.setStartTile(col, row);
+      if (!result.success) {
+        res.status(400).json({ error: result.error });
+        return;
+      }
+      res.json({ success: true, world: content.getWorld() });
+    }
+  });
+
+  // ── Version endpoints ──────────────────────────────────────
+
+  /** List all versions. */
+  router.get('/versions', (_req, res) => {
+    const versions = getVersionStore();
+    res.json({
+      versions: versions.getAll(),
+      activeVersionId: versions.getActiveVersionId(),
+    });
+  });
+
+  /** Create a new draft version. */
+  router.post('/versions', async (req, res) => {
+    const { name, fromVersionId } = req.body;
+    if (!name) {
+      res.status(400).json({ error: 'Missing required field: name' });
+      return;
+    }
+
+    const versions = getVersionStore();
+    let snapshot;
+    if (fromVersionId) {
+      const fromVersion = versions.get(fromVersionId);
+      if (!fromVersion) {
+        res.status(404).json({ error: 'Source version not found.' });
+        return;
+      }
+      snapshot = await versions.loadSnapshot(fromVersionId);
+    } else {
+      // Snapshot from current live content
+      snapshot = getContentStore().toSnapshot();
+    }
+
+    const version = await versions.createDraft(name, fromVersionId ?? null, snapshot);
+    res.json({ success: true, version });
+  });
+
+  /** Get a version's full content snapshot. */
+  router.get('/versions/:id/content', async (req, res) => {
+    const versions = getVersionStore();
+    const version = versions.get(req.params.id);
+    if (!version) {
+      res.status(404).json({ error: 'Version not found.' });
+      return;
+    }
+    const snapshot = await versions.loadSnapshot(req.params.id);
+    res.json(snapshot);
+  });
+
+  /** Rename a draft version. */
+  router.put('/versions/:id', async (req, res) => {
+    const versions = getVersionStore();
+    const version = versions.get(req.params.id);
+    if (!version) {
+      res.status(404).json({ error: 'Version not found.' });
+      return;
+    }
+    if (version.status !== 'draft') {
+      res.status(400).json({ error: 'Only drafts can be renamed.' });
+      return;
+    }
+    if (req.body.name) {
+      version.name = req.body.name;
+      await versions.save();
+    }
+    res.json({ success: true, version });
+  });
+
+  /** Delete a version. */
+  router.delete('/versions/:id', async (req, res) => {
+    const versions = getVersionStore();
+    const result = await versions.deleteVersion(req.params.id);
+    if (!result.success) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    res.json({ success: true });
+  });
+
+  /** Publish a draft version (freeze it). */
+  router.post('/versions/:id/publish', async (req, res) => {
+    const versions = getVersionStore();
+    const result = await versions.publish(req.params.id);
+    if (!result.success) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    res.json({ success: true, version: result.version });
+  });
+
+  /** Deploy a published version to the live game. */
+  router.post('/versions/:id/deploy', async (req, res) => {
+    const result = await deployVersion(req.params.id);
+    if (!result.success) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    res.json({ success: true, relocated: result.relocated });
   });
 
   return router;

--- a/server/src/game/ContentStore.ts
+++ b/server/src/game/ContentStore.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
-import type { MonsterDefinition, ItemDefinition, ZoneDefinition, WorldData } from '@idle-party-rpg/shared';
-import { SEED_MONSTERS, SEED_ITEMS, SEED_ZONES } from '@idle-party-rpg/shared';
+import type { MonsterDefinition, ItemDefinition, ZoneDefinition, WorldData, WorldTileDefinition } from '@idle-party-rpg/shared';
+import { SEED_MONSTERS, SEED_ITEMS, SEED_ZONES, TILE_CONFIGS } from '@idle-party-rpg/shared';
 import { TileType } from '@idle-party-rpg/shared';
 
 const DATA_DIR = path.resolve('data');
@@ -76,6 +76,77 @@ export class ContentStore {
 
   getStartTile(): { col: number; row: number } {
     return this.world.startTile;
+  }
+
+  // --- Tile CRUD ---
+
+  async addOrUpdateTile(tile: WorldTileDefinition): Promise<void> {
+    const idx = this.world.tiles.findIndex(t => t.col === tile.col && t.row === tile.row);
+    if (idx >= 0) {
+      this.world.tiles[idx] = tile;
+    } else {
+      this.world.tiles.push(tile);
+    }
+    await this.save();
+  }
+
+  async deleteTile(col: number, row: number): Promise<{ success: boolean; error?: string }> {
+    const { startTile } = this.world;
+    if (startTile.col === col && startTile.row === row) {
+      return { success: false, error: 'Cannot delete the start tile. Assign a different start tile first.' };
+    }
+
+    const idx = this.world.tiles.findIndex(t => t.col === col && t.row === row);
+    if (idx < 0) {
+      return { success: false, error: 'Tile not found.' };
+    }
+
+    this.world.tiles.splice(idx, 1);
+    await this.save();
+    return { success: true };
+  }
+
+  async setStartTile(col: number, row: number): Promise<{ success: boolean; error?: string }> {
+    const tile = this.world.tiles.find(t => t.col === col && t.row === row);
+    if (!tile) {
+      return { success: false, error: 'Tile not found.' };
+    }
+    const config = TILE_CONFIGS[tile.type];
+    if (!config || !config.traversable) {
+      return { success: false, error: 'Start tile must be traversable.' };
+    }
+    this.world.startTile = { col, row };
+    await this.save();
+    return { success: true };
+  }
+
+  // --- Snapshot ---
+
+  /** Export current live state as a ContentSnapshot. */
+  toSnapshot(): { monsters: MonsterDefinition[]; items: ItemDefinition[]; zones: ZoneDefinition[]; world: WorldData } {
+    return {
+      monsters: Array.from(this.monsters.values()),
+      items: Array.from(this.items.values()),
+      zones: Array.from(this.zones.values()),
+      world: JSON.parse(JSON.stringify(this.world)),
+    };
+  }
+
+  /** Bulk-replace all content from a snapshot (used for deploy). */
+  async replaceAll(snapshot: { monsters: MonsterDefinition[]; items: ItemDefinition[]; zones: ZoneDefinition[]; world: WorldData }): Promise<void> {
+    this.monsters.clear();
+    for (const m of snapshot.monsters) this.monsters.set(m.id, m);
+
+    this.items.clear();
+    for (const i of snapshot.items) this.items.set(i.id, i);
+
+    this.zones.clear();
+    for (const z of snapshot.zones) this.zones.set(z.id, z);
+
+    this.world = snapshot.world;
+
+    await this.save();
+    console.log(`[ContentStore] Replaced all content: ${this.monsters.size} monsters, ${this.items.size} items, ${this.zones.size} zones, ${this.world.tiles.length} tiles`);
   }
 
   // --- Private ---

--- a/server/src/game/GameLoop.ts
+++ b/server/src/game/GameLoop.ts
@@ -3,6 +3,7 @@ import { PlayerManager } from './PlayerManager.js';
 import type { GameStateStore } from './GameStateStore.js';
 import { GuildStore } from './social/GuildStore.js';
 import { ContentStore } from './ContentStore.js';
+import { VersionStore } from './VersionStore.js';
 import type { AccountStore } from '../auth/AccountStore.js';
 
 const SAVE_INTERVAL_MS = 30_000; // Save every 30 seconds
@@ -10,6 +11,7 @@ const SAVE_INTERVAL_MS = 30_000; // Save every 30 seconds
 export class GameLoop {
   readonly playerManager!: PlayerManager;
   readonly contentStore: ContentStore;
+  readonly versionStore: VersionStore;
   private store: GameStateStore;
   private guildStore: GuildStore;
   private saveInterval?: ReturnType<typeof setInterval>;
@@ -17,6 +19,7 @@ export class GameLoop {
 
   constructor(store: GameStateStore) {
     this.contentStore = new ContentStore();
+    this.versionStore = new VersionStore();
     this.guildStore = new GuildStore();
     this.store = store;
   }
@@ -28,6 +31,16 @@ export class GameLoop {
   async init(accountStore: AccountStore): Promise<void> {
     // Load game content from data/*.json (seeds defaults if files missing)
     await this.contentStore.load();
+    await this.versionStore.load();
+
+    // Ensure at least one active version exists (first boot / fresh install)
+    if (!this.versionStore.getActiveVersionId()) {
+      const snapshot = this.contentStore.toSnapshot();
+      const version = await this.versionStore.createDraft('1', null, snapshot);
+      await this.versionStore.publish(version.id);
+      await this.versionStore.setActive(version.id);
+      console.log(`[GameLoop] Created initial version "1" (${version.id})`);
+    }
 
     // Build hex grid from content store world data
     this.grid = this.buildGridFromContent();
@@ -70,6 +83,7 @@ export class GameLoop {
     }
     await this.guildStore.save();
     await this.contentStore.save();
+    await this.versionStore.save();
   }
 
   /**
@@ -84,6 +98,66 @@ export class GameLoop {
     this.playerManager.addShutdownLog();
     await this.saveAll();
     console.log('[GameLoop] State saved on shutdown');
+  }
+
+  /**
+   * Deploy a published version: replace live content, rebuild grid, relocate displaced parties.
+   */
+  async deployVersion(versionId: string): Promise<{ success: boolean; error?: string; relocated?: number }> {
+    const version = this.versionStore.get(versionId);
+    if (!version) return { success: false, error: 'Version not found.' };
+    if (version.status !== 'published') return { success: false, error: 'Only published versions can be deployed.' };
+
+    // 1. Load snapshot and replace live content
+    const snapshot = await this.versionStore.loadSnapshot(versionId);
+    await this.contentStore.replaceAll(snapshot);
+
+    // 2. Rebuild grid, refresh party tiles, relocate displaced parties
+    const relocated = this.rebuildGridAndRelocate();
+
+    // 3. Set as active version
+    await this.versionStore.setActive(versionId);
+
+    // 4. Save all state
+    await this.saveAll();
+
+    // 5. Notify all connected clients that the world has changed
+    this.playerManager.broadcastToAll({ type: 'world_update' });
+
+    // 6. Send updated state to all connected players (zone/position may have changed)
+    for (const username of this.playerManager.getOnlinePlayers()) {
+      this.playerManager.sendStateToPlayer(username);
+    }
+
+    console.log(`[GameLoop] Deployed version "${version.name}" (${versionId}), relocated ${relocated} parties`);
+    return { success: true, relocated };
+  }
+
+  /**
+   * Rebuild the grid and relocate any parties on unreachable tiles.
+   * Used after any content change (deploy or direct tile edit).
+   * Returns the number of parties relocated.
+   */
+  rebuildGridAndRelocate(): number {
+    this.rebuildGrid();
+    this.playerManager.partyBattles.refreshAllPartyTiles(this.grid);
+    return this.playerManager.relocateDisplacedParties(this.grid, this.contentStore);
+  }
+
+  /**
+   * Rebuild the HexGrid in-place from current content store data.
+   * All existing references (PlayerManager, PlayerSession, etc.) remain valid
+   * because the same grid object is reused.
+   */
+  rebuildGrid(): void {
+    this.grid.clear();
+    const world = this.contentStore.getWorld();
+    for (const tileDef of world.tiles) {
+      const coord = offsetToCube({ col: tileDef.col, row: tileDef.row });
+      const tile = new HexTile(coord, tileDef.type, tileDef.zone);
+      this.grid.addTile(tile);
+    }
+    console.log(`[GameLoop] Grid rebuilt: ${this.grid.size} tiles`);
   }
 
   /**

--- a/server/src/game/PartyBattleManager.ts
+++ b/server/src/game/PartyBattleManager.ts
@@ -208,6 +208,13 @@ export class PartyBattleManager {
     }
   }
 
+  /** Restart the current battle for a party (e.g., after a member changes class). */
+  restartBattle(partyId: string): void {
+    const entry = this.entries.get(partyId);
+    if (!entry) return;
+    entry.battleTimer.restartBattle();
+  }
+
   /** Destroy a party battle entry and stop its timers. */
   destroyEntry(partyId: string): void {
     const entry = this.entries.get(partyId);
@@ -328,6 +335,40 @@ export class PartyBattleManager {
     const posA = cubeToOffset(a.serverParty.position);
     const posB = cubeToOffset(b.serverParty.position);
     return posA.col === posB.col && posA.row === posB.row;
+  }
+
+  /** Get all party IDs. */
+  getAllPartyIds(): string[] {
+    return Array.from(this.entries.keys());
+  }
+
+  /** Get members of a party. */
+  getMembers(partyId: string): Set<string> | undefined {
+    return this.entries.get(partyId)?.members;
+  }
+
+  /** Relocate a party to a new tile, restarting its battle. */
+  relocateParty(partyId: string, newTile: HexTile): void {
+    const entry = this.entries.get(partyId);
+    if (!entry) return;
+    entry.serverParty.relocateTo(newTile);
+    entry.battleTimer.restartBattle();
+  }
+
+  /**
+   * After a grid rebuild, re-resolve all parties' tile references.
+   * The grid object is the same but tiles inside it are new instances.
+   */
+  refreshAllPartyTiles(grid: HexGrid): void {
+    for (const entry of this.entries.values()) {
+      const pos = cubeToOffset(entry.serverParty.position);
+      const coord = offsetToCube(pos);
+      const freshTile = grid.getTile(coord);
+      if (freshTile) {
+        // Re-set to the same position but with fresh tile reference
+        entry.serverParty.relocateTo(freshTile);
+      }
+    }
   }
 
   // --- Private ---

--- a/server/src/game/PlayerManager.ts
+++ b/server/src/game/PlayerManager.ts
@@ -1,6 +1,6 @@
 import { WebSocket } from 'ws';
-import { HexGrid, offsetToCube } from '@idle-party-rpg/shared';
-import type { OtherPlayerState, ClientSocialState, ChatMessage, BlockLevel, PartyGridPosition, PartyRole } from '@idle-party-rpg/shared';
+import { HexGrid, offsetToCube, cubeDistance, cubeToKey } from '@idle-party-rpg/shared';
+import type { HexTile, OtherPlayerState, ClientSocialState, ChatMessage, BlockLevel, PartyGridPosition, PartyRole } from '@idle-party-rpg/shared';
 import { PlayerSession } from './PlayerSession.js';
 import type { GameStateStore, PlayerSaveData } from './GameStateStore.js';
 import { FriendsSystem } from './social/FriendsSystem.js';
@@ -164,6 +164,18 @@ export class PlayerManager {
     for (const ws of wsSet) {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(state);
+      }
+    }
+  }
+
+  /** Broadcast a message to all connected clients. */
+  broadcastToAll(message: Record<string, unknown>): void {
+    const payload = JSON.stringify(message);
+    for (const wsSet of this.playerConnections.values()) {
+      for (const ws of wsSet) {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(payload);
+        }
       }
     }
   }
@@ -511,6 +523,64 @@ export class PlayerManager {
         movementQueue,
       );
     }
+  }
+
+  /**
+   * After a deploy, find all parties on unreachable tiles and relocate them.
+   * Returns the number of parties relocated.
+   */
+  relocateDisplacedParties(grid: HexGrid, content: ContentStore): number {
+    const startPos = content.getStartTile();
+    const startCoord = offsetToCube(startPos);
+    const reachable = grid.getReachableTiles(startCoord);
+
+    let relocated = 0;
+
+    for (const partyId of this.partyBattles.getAllPartyIds()) {
+      const tile = this.partyBattles.getTile(partyId);
+      if (!tile) continue;
+
+      const tileKey = cubeToKey(tile.coord);
+      if (reachable.has(tileKey)) continue;
+
+      // Find nearest reachable tile
+      let bestTile: HexTile | null = null;
+      let bestDist = Infinity;
+      for (const key of reachable) {
+        const candidate = grid.getTileByKey(key);
+        if (!candidate) continue;
+        const dist = cubeDistance(tile.coord, candidate.coord);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestTile = candidate;
+        }
+      }
+
+      if (!bestTile) {
+        // Fallback to start tile
+        bestTile = grid.getTile(startCoord) ?? null;
+        if (!bestTile) continue;
+      }
+
+      // Relocate the party
+      this.partyBattles.relocateParty(partyId, bestTile);
+
+      // Unlock the area for all members and log
+      const members = this.partyBattles.getMembers(partyId);
+      if (members) {
+        for (const username of members) {
+          const session = this.sessions.get(username);
+          if (session) {
+            session.forceUnlockTileArea(bestTile);
+            session.addLogEntry('World updated — relocated to a safe room.', 'move');
+          }
+        }
+      }
+
+      relocated++;
+    }
+
+    return relocated;
   }
 
   /**

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -306,6 +306,15 @@ export class PlayerSession {
     }
   }
 
+  /** Force-unlock a tile and its adjacent tiles (for relocation after deploy). */
+  forceUnlockTileArea(tile: HexTile): void {
+    this.unlockSystem.forceUnlock(tile);
+    const neighbors = this.grid.getTraversableNeighbors(tile.coord);
+    for (const neighbor of neighbors) {
+      this.unlockSystem.forceUnlock(neighbor);
+    }
+  }
+
   getStartingTile(): HexTile {
     const startPos = this.content.getStartTile();
     const startCoord = offsetToCube(startPos);

--- a/server/src/game/ServerBattleTimer.ts
+++ b/server/src/game/ServerBattleTimer.ts
@@ -167,6 +167,12 @@ export class ServerBattleTimer {
     return this.combatState;
   }
 
+  /** Restart the current battle (e.g., after a player changes class). */
+  restartBattle(): void {
+    this.clearTimers();
+    this.triggerBattle();
+  }
+
   destroy(): void {
     this.clearTimers();
   }

--- a/server/src/game/ServerParty.ts
+++ b/server/src/game/ServerParty.ts
@@ -104,6 +104,13 @@ export class ServerParty {
     return true;
   }
 
+  /** Force-relocate the party to a new tile, clearing all movement state. */
+  relocateTo(tile: HexTile): void {
+    this.currentTile = tile;
+    this.targetTile = null;
+    this.movementQueue = [];
+  }
+
   enterBattle(): void {
     this.setState('in_battle');
   }

--- a/server/src/game/VersionStore.ts
+++ b/server/src/game/VersionStore.ts
@@ -1,0 +1,151 @@
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import type { MonsterDefinition, ItemDefinition, ZoneDefinition, WorldData } from '@idle-party-rpg/shared';
+
+export type VersionStatus = 'draft' | 'published';
+
+export interface ContentSnapshot {
+  monsters: MonsterDefinition[];
+  items: ItemDefinition[];
+  zones: ZoneDefinition[];
+  world: WorldData;
+}
+
+export interface ContentVersion {
+  id: string;
+  name: string;
+  status: VersionStatus;
+  isActive: boolean;
+  createdAt: string;
+  createdFrom: string | null;
+  publishedAt: string | null;
+}
+
+interface VersionManifest {
+  versions: ContentVersion[];
+  activeVersionId: string | null;
+}
+
+const VERSIONS_DIR = path.resolve('data', 'versions');
+const MANIFEST_FILE = path.join(VERSIONS_DIR, 'manifest.json');
+
+/**
+ * Manages content version snapshots.
+ * Each version is a complete freeze of all game content (monsters, items, zones, world).
+ */
+export class VersionStore {
+  private manifest: VersionManifest = { versions: [], activeVersionId: null };
+
+  async load(): Promise<void> {
+    try {
+      const raw = await fs.readFile(MANIFEST_FILE, 'utf-8');
+      this.manifest = JSON.parse(raw);
+      console.log(`[VersionStore] Loaded ${this.manifest.versions.length} versions`);
+    } catch {
+      // No manifest yet — start empty
+      console.log('[VersionStore] No versions found — starting fresh');
+    }
+  }
+
+  async save(): Promise<void> {
+    await fs.mkdir(VERSIONS_DIR, { recursive: true });
+    await fs.writeFile(MANIFEST_FILE, JSON.stringify(this.manifest, null, 2));
+  }
+
+  getAll(): ContentVersion[] {
+    return this.manifest.versions;
+  }
+
+  get(id: string): ContentVersion | undefined {
+    return this.manifest.versions.find(v => v.id === id);
+  }
+
+  getActive(): ContentVersion | undefined {
+    if (!this.manifest.activeVersionId) return undefined;
+    return this.get(this.manifest.activeVersionId);
+  }
+
+  getActiveVersionId(): string | null {
+    return this.manifest.activeVersionId;
+  }
+
+  async createDraft(name: string, fromVersionId: string | null, snapshot: ContentSnapshot): Promise<ContentVersion> {
+    const id = crypto.randomUUID();
+    const version: ContentVersion = {
+      id,
+      name,
+      status: 'draft',
+      isActive: false,
+      createdAt: new Date().toISOString(),
+      createdFrom: fromVersionId,
+      publishedAt: null,
+    };
+
+    await this.saveSnapshot(id, snapshot);
+    this.manifest.versions.push(version);
+    await this.save();
+
+    console.log(`[VersionStore] Created draft "${name}" (${id})`);
+    return version;
+  }
+
+  async publish(id: string): Promise<{ success: boolean; version?: ContentVersion; error?: string }> {
+    const version = this.get(id);
+    if (!version) return { success: false, error: 'Version not found.' };
+    if (version.status !== 'draft') return { success: false, error: 'Only drafts can be published.' };
+
+    version.status = 'published';
+    version.publishedAt = new Date().toISOString();
+    await this.save();
+
+    console.log(`[VersionStore] Published "${version.name}" (${id})`);
+    return { success: true, version };
+  }
+
+  async setActive(id: string): Promise<void> {
+    // Clear old active
+    for (const v of this.manifest.versions) {
+      v.isActive = false;
+    }
+    const version = this.get(id);
+    if (version) {
+      version.isActive = true;
+    }
+    this.manifest.activeVersionId = id;
+    await this.save();
+  }
+
+  async deleteVersion(id: string): Promise<{ success: boolean; error?: string }> {
+    const version = this.get(id);
+    if (!version) return { success: false, error: 'Version not found.' };
+    if (version.isActive) return { success: false, error: 'Cannot delete the active version.' };
+
+    // Remove snapshot file
+    try {
+      await fs.unlink(this.snapshotPath(id));
+    } catch {
+      // File may not exist
+    }
+
+    this.manifest.versions = this.manifest.versions.filter(v => v.id !== id);
+    await this.save();
+
+    console.log(`[VersionStore] Deleted "${version.name}" (${id})`);
+    return { success: true };
+  }
+
+  async loadSnapshot(id: string): Promise<ContentSnapshot> {
+    const raw = await fs.readFile(this.snapshotPath(id), 'utf-8');
+    return JSON.parse(raw);
+  }
+
+  async saveSnapshot(id: string, snapshot: ContentSnapshot): Promise<void> {
+    await fs.mkdir(VERSIONS_DIR, { recursive: true });
+    await fs.writeFile(this.snapshotPath(id), JSON.stringify(snapshot, null, 2));
+  }
+
+  private snapshotPath(id: string): string {
+    return path.join(VERSIONS_DIR, `${id}.json`);
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,13 @@
-import 'dotenv/config';
+import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load .env from project root (npm workspaces set CWD to server/)
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+dotenv.config(); // Also check server/.env (does not override existing vars)
 import express from 'express';
 import session from 'express-session';
 import cors from 'cors';
@@ -87,6 +94,9 @@ app.use('/api/admin', createAdminRoutes({
   playerManager: () => playerManager,
   accountStore,
   contentStore: () => gameLoop.contentStore,
+  versionStore: () => gameLoop.versionStore,
+  rebuildGrid: () => gameLoop.rebuildGridAndRelocate(),
+  deployVersion: (versionId) => gameLoop.deployVersion(versionId),
 }));
 
 app.get('/health', (_req, res) => {
@@ -99,7 +109,6 @@ app.get('/health', (_req, res) => {
 
 // --- Static files (production: serve built client) ---
 if (process.env.NODE_ENV === 'production') {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const clientDist = path.resolve(__dirname, '../../client/dist');
   app.use(express.static(clientDist));
   // SPA fallback — serve the correct HTML for admin vs game routes
@@ -240,6 +249,11 @@ wss.on('connection', (ws) => {
         if (!session.setClass(msg.className as ClassName)) {
           ws.send(JSON.stringify({ type: 'error', message: 'Cannot change class' }));
           return;
+        }
+        // Restart the current battle so combat uses the new class data
+        const classPartyId = session.getPartyId();
+        if (classPartyId) {
+          playerManager.partyBattles.restartBattle(classPartyId);
         }
         playerManager.sendStateToPlayer(username);
         return;

--- a/shared/src/hex/HexGrid.ts
+++ b/shared/src/hex/HexGrid.ts
@@ -13,6 +13,13 @@ export class HexGrid {
   }
 
   /**
+   * Remove all tiles from the grid.
+   */
+  clear(): void {
+    this.tiles.clear();
+  }
+
+  /**
    * Get a tile by its cube coordinates.
    */
   getTile(coord: CubeCoord): HexTile | undefined {
@@ -87,6 +94,34 @@ export class HexGrid {
    */
   get size(): number {
     return this.tiles.size;
+  }
+
+  /**
+   * BFS from a starting tile to find all reachable traversable tiles.
+   * Returns a Set of tile keys that are reachable.
+   */
+  getReachableTiles(start: CubeCoord): Set<string> {
+    const startTile = this.getTile(start);
+    if (!startTile || !startTile.isTraversable) return new Set();
+
+    const visited = new Set<string>();
+    const queue: CubeCoord[] = [start];
+    visited.add(cubeToKey(start));
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      for (const neighbor of getNeighbors(current)) {
+        const key = cubeToKey(neighbor);
+        if (visited.has(key)) continue;
+        const tile = this.getTile(neighbor);
+        if (tile && tile.isTraversable) {
+          visited.add(key);
+          queue.push(neighbor);
+        }
+      }
+    }
+
+    return visited;
   }
 
   /**

--- a/shared/src/systems/UnlockSystem.ts
+++ b/shared/src/systems/UnlockSystem.ts
@@ -80,6 +80,13 @@ export class UnlockSystem {
   }
 
   /**
+   * Force-unlock a tile (no event, idempotent). Used for relocation after deploy.
+   */
+  forceUnlock(tile: HexTile): void {
+    this.unlockedKeys.add(tile.key);
+  }
+
+  /**
    * Get all unlocked tiles.
    */
   getUnlockedTiles(): HexTile[] {


### PR DESCRIPTION
## Summary

- **Content versioning pipeline**: Admin edits go through draft → publish → deploy workflow. `VersionStore` manages version metadata and snapshots. On first boot, version "1" is auto-created as published + active.
- **Always-version admin UI**: Removed "live editing" mode from World Manager — admin always views/edits a specific content version. Version bar shows editing/viewing status with badges.
- **Party relocation on deploy**: When deploying content changes that make tiles unreachable, parties are automatically relocated to the nearest navigable tile via BFS from the start tile.
- **Live world updates via WebSocket**: After deploy, server broadcasts `world_update` signal to all connected game clients. Clients re-fetch world data and rebuild the map automatically — no page refresh needed.

## Test plan

- [x] `npm run typecheck` — no type errors
- [x] `npm run test` — all 187 tests pass
- [ ] Delete `data/versions/` → restart server → verify version "1" auto-created as published + active
- [ ] Open admin → verify always viewing a version (no "live" option) on all tabs
- [ ] Create draft → edit tiles → publish → deploy → verify game client map updates automatically
- [ ] Deploy content that removes tiles with parties → verify parties relocated

🤖 Generated with [Claude Code](https://claude.com/claude-code)