### PR TITLE
Document worktree npm install requirement (fixes #29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ npm run test:shared  # Shared package tests only
 npm run typecheck    # tsc --build (all packages)
 ```
 
-**Worktree setup**: Git worktrees do not share `node_modules` with the main repo. When working in a worktree, run `npm install` before building. The shared package must be built before client/server can typecheck (project references resolve via `dist/` output, not source).
+**Worktree setup**: Git worktrees need their own `node_modules`. Without it, workspace symlinks resolve through the main repo's `node_modules` to its stale `shared/dist/` types, causing false type errors. **Always run `npm install` immediately after entering a worktree** (before build, typecheck, or any other commands).
 
 ## Architecture & Patterns
 


### PR DESCRIPTION
## Summary
- Clarifies CLAUDE.md worktree setup instructions to explain **why** `npm install` is needed (workspace symlinks resolve to main repo's stale `shared/dist/` types)
- Makes the instruction bold and prominent so it's not missed

## Root cause
The ~40 type errors from issue #29 were not real code errors. In a worktree without local `node_modules`, the `@idle-party-rpg/shared` workspace symlink resolves through the main repo's `node_modules` → `../../shared` → main repo's `shared/dist/` (which has stale type declarations). Running `npm install` in the worktree creates local `node_modules` with symlinks pointing to the worktree's own `shared/`.

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (188 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)