### PR TITLE
Add per-room encounter table overrides

### DIFF
--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -2214,6 +2214,15 @@ export class AdminApp {
           <label>Coordinates</label>
           <div class="admin-map-sidebar-coords">(${tile.col}, ${tile.row})</div>
         </div>
+        <div class="admin-map-sidebar-field">
+          <label>
+            <input type="checkbox" id="sidebar-custom-encounters" ${tile.encounterTable?.length ? 'checked' : ''}${disabled} />
+            Custom Encounters
+          </label>
+        </div>
+        <div id="sidebar-encounters-section" style="${tile.encounterTable?.length ? '' : 'display:none'}">
+          ${this.renderSidebarEncounterRows(tile, displayContent ? Object.values(displayContent.monsters) : [], readOnly)}
+        </div>
         ${startBtnHtml}
         <div class="admin-map-sidebar-spacer"></div>
         ${deleteBtnHtml}
@@ -2249,6 +2258,28 @@ export class AdminApp {
       }
     });
 
+    const customEncCheck = document.getElementById('sidebar-custom-encounters') as HTMLInputElement;
+    customEncCheck?.addEventListener('change', () => {
+      const section = document.getElementById('sidebar-encounters-section');
+      if (section && this.selectedTile) {
+        if (customEncCheck.checked) {
+          if (!this.selectedTile.encounterTable || this.selectedTile.encounterTable.length === 0) {
+            this.selectedTile.encounterTable = [];
+          }
+          section.style.display = '';
+          const displayContent = this.getDisplayContent();
+          section.innerHTML = this.renderSidebarEncounterRows(this.selectedTile, displayContent ? Object.values(displayContent.monsters) : [], this.isReadOnly());
+          this.wireSidebarEncounterEvents();
+        } else {
+          delete this.selectedTile.encounterTable;
+          section.style.display = 'none';
+          this.scheduleSave();
+        }
+      }
+    });
+
+    this.wireSidebarEncounterEvents();
+
     document.getElementById('sidebar-set-start')?.addEventListener('click', () => {
       this.setAsStartTile();
     });
@@ -2261,6 +2292,101 @@ export class AdminApp {
       nameInput.focus();
       nameInput.select();
     }
+  }
+
+  private renderSidebarEncounterRows(tile: WorldTileDefinition, monsters: MonsterDefinition[], readOnly: boolean): string {
+    const disabled = readOnly ? ' disabled' : '';
+    const entries = tile.encounterTable ?? [];
+    const rows = entries.map((e, i) => {
+      const options = monsters.map(m =>
+        `<option value="${m.id}" ${m.id === e.monsterId ? 'selected' : ''}>${this.escapeHtml(m.name)}</option>`
+      ).join('');
+      return `
+        <div class="monster-drop-row sidebar-enc-row" data-index="${i}">
+          <select class="sidebar-enc-monster"${disabled}>${options}</select>
+          <label class="zf-enc-inline">W<input type="number" class="sidebar-enc-weight" value="${e.weight}" min="1" step="1"${disabled}></label>
+          <label class="zf-enc-inline">Min<input type="number" class="sidebar-enc-min" value="${e.minCount}" min="1" step="1"${disabled}></label>
+          <label class="zf-enc-inline">Max<input type="number" class="sidebar-enc-max" value="${e.maxCount}" min="1" step="1"${disabled}></label>
+          ${readOnly ? '' : '<button class="admin-btn admin-btn-sm admin-btn-danger sidebar-enc-remove">X</button>'}
+        </div>
+      `;
+    }).join('');
+
+    const addBtn = readOnly ? '' : '<button class="admin-btn admin-btn-sm" id="sidebar-add-encounter">+ Encounter</button>';
+    return `${addBtn}<div id="sidebar-encounters-list">${rows}</div>`;
+  }
+
+  private wireSidebarEncounterEvents(): void {
+    document.getElementById('sidebar-add-encounter')?.addEventListener('click', () => {
+      if (!this.selectedTile) return;
+      const displayContent = this.getDisplayContent();
+      const monsters = displayContent ? Object.values(displayContent.monsters) : [];
+      if (monsters.length === 0) return;
+
+      if (!this.selectedTile.encounterTable) this.selectedTile.encounterTable = [];
+      this.selectedTile.encounterTable.push({ monsterId: monsters[0].id, weight: 1, minCount: 1, maxCount: 1 });
+      this.scheduleSave();
+
+      // Re-render encounter section
+      const section = document.getElementById('sidebar-encounters-section');
+      if (section) {
+        section.innerHTML = this.renderSidebarEncounterRows(this.selectedTile, monsters, this.isReadOnly());
+        this.wireSidebarEncounterEvents();
+      }
+    });
+
+    // Wire remove buttons
+    document.querySelectorAll('.sidebar-enc-remove').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (!this.selectedTile?.encounterTable) return;
+        const row = (btn as HTMLElement).closest('.sidebar-enc-row');
+        const index = parseInt(row?.getAttribute('data-index') ?? '-1');
+        if (index >= 0) {
+          this.selectedTile.encounterTable.splice(index, 1);
+          this.scheduleSave();
+          const section = document.getElementById('sidebar-encounters-section');
+          const displayContent = this.getDisplayContent();
+          if (section) {
+            section.innerHTML = this.renderSidebarEncounterRows(this.selectedTile, displayContent ? Object.values(displayContent.monsters) : [], this.isReadOnly());
+            this.wireSidebarEncounterEvents();
+          }
+        }
+      });
+    });
+
+    // Wire change events on all encounter inputs
+    document.querySelectorAll('.sidebar-enc-row').forEach(row => {
+      const index = parseInt(row.getAttribute('data-index') ?? '-1');
+      if (index < 0) return;
+
+      row.querySelector('.sidebar-enc-monster')?.addEventListener('change', (e) => {
+        if (this.selectedTile?.encounterTable?.[index]) {
+          this.selectedTile.encounterTable[index].monsterId = (e.target as HTMLSelectElement).value;
+          this.scheduleSave();
+        }
+      });
+
+      row.querySelector('.sidebar-enc-weight')?.addEventListener('input', (e) => {
+        if (this.selectedTile?.encounterTable?.[index]) {
+          this.selectedTile.encounterTable[index].weight = parseInt((e.target as HTMLInputElement).value) || 1;
+          this.scheduleSave();
+        }
+      });
+
+      row.querySelector('.sidebar-enc-min')?.addEventListener('input', (e) => {
+        if (this.selectedTile?.encounterTable?.[index]) {
+          this.selectedTile.encounterTable[index].minCount = parseInt((e.target as HTMLInputElement).value) || 1;
+          this.scheduleSave();
+        }
+      });
+
+      row.querySelector('.sidebar-enc-max')?.addEventListener('input', (e) => {
+        if (this.selectedTile?.encounterTable?.[index]) {
+          this.selectedTile.encounterTable[index].maxCount = parseInt((e.target as HTMLInputElement).value) || 1;
+          this.scheduleSave();
+        }
+      });
+    });
   }
 
   private showSidebarError(message: string): void {

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -58,11 +58,24 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
   /** Add or update a world tile. Supports ?versionId= for draft editing. */
   router.put('/world/tile', async (req, res) => {
     const versionId = req.query.versionId as string | undefined;
-    const { col, row, type, zone, name } = req.body;
+    const { col, row, type, zone, name, encounterTable } = req.body;
     if (col == null || row == null || !type || !zone || !name) {
       res.status(400).json({ error: 'Missing required fields: col, row, type, zone, name' });
       return;
     }
+
+    // Validate optional encounter table entries
+    if (encounterTable != null && Array.isArray(encounterTable)) {
+      for (const entry of encounterTable) {
+        if (!entry.monsterId || entry.weight == null || entry.minCount == null || entry.maxCount == null) {
+          res.status(400).json({ error: 'Each encounter entry requires: monsterId, weight, minCount, maxCount' });
+          return;
+        }
+      }
+    }
+
+    // Only include encounterTable if it has entries
+    const tileEncounterTable = Array.isArray(encounterTable) && encounterTable.length > 0 ? encounterTable : undefined;
 
     if (versionId) {
       const versions = getVersionStore();
@@ -73,16 +86,16 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
       const idx = snapshot.world.tiles.findIndex(t => t.col === col && t.row === row);
       if (idx >= 0) {
         // Preserve existing GUID on update
-        snapshot.world.tiles[idx] = { id: snapshot.world.tiles[idx].id, col, row, type, zone, name };
+        snapshot.world.tiles[idx] = { id: snapshot.world.tiles[idx].id, col, row, type, zone, name, encounterTable: tileEncounterTable };
       } else {
         // New tile — generate a GUID
-        snapshot.world.tiles.push({ id: crypto.randomUUID(), col, row, type, zone, name });
+        snapshot.world.tiles.push({ id: crypto.randomUUID(), col, row, type, zone, name, encounterTable: tileEncounterTable });
       }
       await versions.saveSnapshot(versionId, snapshot);
       res.json({ success: true, world: snapshot.world });
     } else {
       const content = getContentStore();
-      await content.addOrUpdateTile({ id: '', col, row, type, zone, name });
+      await content.addOrUpdateTile({ id: '', col, row, type, zone, name, encounterTable: tileEncounterTable });
       const relocated = rebuildGrid();
       res.json({ success: true, world: content.getWorld(), relocated });
     }

--- a/server/src/game/ContentStore.ts
+++ b/server/src/game/ContentStore.ts
@@ -79,6 +79,10 @@ export class ContentStore {
     return this.world.startTile;
   }
 
+  getTileById(id: string): WorldTileDefinition | undefined {
+    return this.world.tiles.find(t => t.id === id);
+  }
+
   // --- Tile CRUD ---
 
   async addOrUpdateTile(tile: WorldTileDefinition): Promise<void> {

--- a/server/src/game/PartyBattleManager.ts
+++ b/server/src/game/PartyBattleManager.ts
@@ -392,7 +392,9 @@ export class PartyBattleManager {
     }
 
     const zone = entry.serverParty.tile.zone;
-    const monsters = createEncounter(zone, allMonsters, allZones);
+    const tileId = entry.serverParty.tile.id;
+    const tileDef = this.content.getTileById(tileId);
+    const monsters = createEncounter(zone, allMonsters, allZones, tileDef?.encounterTable);
 
     return createPartyCombatState(players, monsters);
   }

--- a/shared/src/hex/MapSchema.ts
+++ b/shared/src/hex/MapSchema.ts
@@ -1,4 +1,5 @@
 import { TileType } from './HexTile.js';
+import type { EncounterTableEntry } from '../systems/ZoneTypes.js';
 
 /**
  * Schema for defining a map.
@@ -30,6 +31,8 @@ export interface WorldTileDefinition {
   name: string;
   /** Zone display name — populated by server when sending to clients, not stored in world.json. */
   zoneName?: string;
+  /** Optional per-room encounter table — overrides the zone's default encounters. */
+  encounterTable?: EncounterTableEntry[];
 }
 
 /**

--- a/shared/src/systems/MonsterTypes.ts
+++ b/shared/src/systems/MonsterTypes.ts
@@ -113,34 +113,36 @@ function pickWeightedEntry(table: EncounterTableEntry[]): EncounterTableEntry {
 }
 
 /**
- * Create an encounter for the given zone.
- * Uses the zone's encounter table for weighted random monster selection.
- * Falls back to first available monster if zone or monster not found.
+ * Create an encounter for the given zone, with optional room-level override.
+ * Priority: roomEncounterTable → zone's encounterTable → goblin fallback.
  */
 export function createEncounter(
   zoneId: string | undefined,
   monsters: Record<string, MonsterDefinition>,
   zones: Record<string, ZoneDefinition>,
+  roomEncounterTable?: EncounterTableEntry[],
 ): MonsterInstance[] {
   const fallbackDef = monsters['goblin'] ?? Object.values(monsters)[0];
   if (!fallbackDef) return [];
 
-  if (!zoneId) {
+  // Determine which encounter table to use: room override → zone default
+  let encounterTable: EncounterTableEntry[] | undefined = roomEncounterTable?.length ? roomEncounterTable : undefined;
+
+  if (!encounterTable && zoneId) {
+    const zone = zones[zoneId];
+    if (zone) {
+      encounterTable = zone.encounterTable;
+    }
+  }
+
+  if (!encounterTable || encounterTable.length === 0) {
     return [
       createMonsterInstance(fallbackDef, MONSTER_GRID_POSITIONS[0]),
       createMonsterInstance(fallbackDef, MONSTER_GRID_POSITIONS[1]),
     ];
   }
 
-  const zone = zones[zoneId];
-  if (!zone) {
-    return [
-      createMonsterInstance(fallbackDef, MONSTER_GRID_POSITIONS[0]),
-      createMonsterInstance(fallbackDef, MONSTER_GRID_POSITIONS[1]),
-    ];
-  }
-
-  const entry = pickWeightedEntry(zone.encounterTable);
+  const entry = pickWeightedEntry(encounterTable);
   const def = monsters[entry.monsterId];
   if (!def) {
     return [

--- a/shared/tests/ZoneTypes.test.ts
+++ b/shared/tests/ZoneTypes.test.ts
@@ -74,5 +74,23 @@ describe('ZoneTypes', () => {
       expect(monsters).toHaveLength(2);
       expect(monsters[0].id).toBe('goblin');
     });
+
+    it('uses room encounter table override when provided', () => {
+      const roomTable = [{ monsterId: 'wolf', weight: 1, minCount: 2, maxCount: 2 }];
+      // Even though zone is hatchetmill (goblins only), room override should produce wolves
+      const monsters = createEncounter('hatchetmill', SEED_MONSTERS, SEED_ZONES, roomTable);
+      expect(monsters).toHaveLength(2);
+      for (const m of monsters) {
+        expect(m.id).toBe('wolf');
+      }
+    });
+
+    it('falls back to zone table when room encounter table is empty', () => {
+      const monsters = createEncounter('hatchetmill', SEED_MONSTERS, SEED_ZONES, []);
+      expect(monsters.length).toBeGreaterThanOrEqual(1);
+      for (const m of monsters) {
+        expect(m.id).toBe('goblin');
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Rooms can now have their own encounter table that overrides their zone's default encounters
- Encounter resolution priority: room encounterTable → zone encounterTable → goblin fallback
- Admin panel tile sidebar includes a "Custom Encounters" toggle with full encounter table editor (monster selector, weight, min/max count)
- Server API validates optional encounter table entries on tile save

## Test plan
- [x] Typecheck passes
- [x] All 190 tests pass (including 2 new tests for room encounter override and empty fallback)
- [ ] Verify in admin panel: click a room, toggle "Custom Encounters", add/edit/remove encounter entries
- [ ] Verify combat uses room encounters when set, falls back to zone encounters when not

🤖 Generated with [Claude Code](https://claude.com/claude-code)