### PR TITLE
Improve XP rate widget with boxed layout and reset confirmation

### DIFF
--- a/client/src/screens/CharacterScreen.ts
+++ b/client/src/screens/CharacterScreen.ts
@@ -83,8 +83,9 @@ export class CharacterScreen implements Screen {
               <div class="character-xp-fill" style="width: 0%"></div>
             </div>
             <div class="character-xp-rate">
+              <span class="character-xp-rate-label">XP Rate</span>
               <span class="character-xp-rate-value">0/hr</span>
-              <button class="character-xp-rate-reset" title="Reset XP rate counter">Reset</button>
+              <span class="character-xp-rate-reset" title="Reset XP rate counter">&#x21bb;</span>
             </div>
           </div>
           <div class="character-hp-display">
@@ -121,12 +122,21 @@ export class CharacterScreen implements Screen {
     this.statsTable = this.container.querySelector('.character-stats-tbody')!;
     this.xpRateEl = this.container.querySelector('.character-xp-rate-value')!;
 
-    // Wire XP rate reset button
-    this.container.querySelector('.character-xp-rate-reset')!.addEventListener('click', () => {
-      this.xpRateStartTime = Date.now();
-      this.xpRateTotal = 0;
-      this.lastTotalXp = -1;
-      this.xpRateEl.textContent = '0/hr';
+    // Wire XP rate reset icon with confirmation
+    const resetIcon = this.container.querySelector('.character-xp-rate-reset')!;
+    resetIcon.addEventListener('click', () => {
+      if (resetIcon.classList.contains('confirming')) {
+        // Second click — perform reset
+        resetIcon.classList.remove('confirming');
+        this.xpRateStartTime = Date.now();
+        this.xpRateTotal = 0;
+        this.lastTotalXp = -1;
+        this.xpRateEl.textContent = '0/hr';
+        return;
+      }
+      // First click — enter confirmation state
+      resetIcon.classList.add('confirming');
+      setTimeout(() => resetIcon.classList.remove('confirming'), 3000);
     });
   }
 

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -546,10 +546,20 @@ html, body {
 }
 
 .character-xp-rate {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 6px;
   font-size: 7px;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-pixel);
+  border-radius: 4px;
+  padding: 3px 8px;
+  margin-top: 4px;
+  background: var(--bg-darker);
+}
+
+.character-xp-rate-label {
+  font-family: var(--pixel-font);
   color: var(--text-secondary);
 }
 
@@ -559,18 +569,24 @@ html, body {
 }
 
 .character-xp-rate-reset {
-  font-family: var(--pixel-font);
-  font-size: 6px;
-  padding: 1px 6px;
-  background: var(--bg-input);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-pixel);
   cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  transition: color 0.15s;
 }
 
 .character-xp-rate-reset:hover {
-  background: var(--border-pixel);
   color: var(--text-primary);
+}
+
+.character-xp-rate-reset.confirming {
+  color: var(--hp-low);
+  animation: xp-reset-pulse 0.6s ease-in-out infinite;
+}
+
+@keyframes xp-reset-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 .character-hp-display {


### PR DESCRIPTION
## Summary
- Restyle XP rate counter as a self-contained boxed widget (border, background, rounded corners)
- Add "XP Rate" label before the value
- Group label, value, and reset icon inline with consistent spacing
- Replace text "Reset" button with ↻ icon (tooltip on hover)
- Add two-click confirmation: first click pulses icon red for 3s, second click resets

## Test plan
- [ ] XP rate widget renders as a compact boxed component on Character tab
- [ ] Hovering the ↻ icon shows "Reset XP rate counter" tooltip
- [ ] First click on ↻ makes it pulse red; clicking again resets the counter
- [ ] If not confirmed within 3s, icon returns to normal without resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)