### PR TITLE
Fix XP rate calculator NaN on restored sessions

### DIFF
--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -478,6 +478,10 @@ export class PlayerSession {
     session['chatSendChannel'] = (data.chatSendChannel as ChatChannelType) ?? 'zone';
     session['chatDmTarget'] = data.chatDmTarget ?? '';
 
+    // XP rate tracking — auto-start from session restore time
+    session['xpRateStartTime'] = Date.now();
+    session['xpRateXpTotal'] = 0;
+
     // Add server-online log entry
     session['addLogEntry']('Server back online — resuming!', 'battle');
 


### PR DESCRIPTION
## Summary
- `PlayerSession.fromSaveData()` bypasses the constructor via `Object.create`, so `xpRateStartTime` and `xpRateXpTotal` were never initialized (remained `undefined`)
- Client computed `Date.now() - undefined = NaN`, displaying NaN in the XP rate
- Now initializes both fields in `fromSaveData()` so XP rate auto-starts tracking from session restore time — no manual reset required

## Test plan
- [x] All 189 tests pass
- [ ] Verify XP rate shows a valid number immediately after server restart (no reset needed)

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)