### PR TITLE
Add welcome message for new players in chat

### DIFF
--- a/server/src/game/PlayerManager.ts
+++ b/server/src/game/PlayerManager.ts
@@ -1,6 +1,6 @@
 import { WebSocket } from 'ws';
-import { HexGrid, offsetToCube, cubeDistance, cubeToKey } from '@idle-party-rpg/shared';
-import type { HexTile, OtherPlayerState, ClientSocialState, ChatMessage, BlockLevel, PartyGridPosition, PartyRole } from '@idle-party-rpg/shared';
+import { HexGrid, offsetToCube, cubeDistance, cubeToKey, CLASS_ICONS } from '@idle-party-rpg/shared';
+import type { HexTile, OtherPlayerState, ClientSocialState, ChatMessage, BlockLevel, PartyGridPosition, PartyRole, ClassName } from '@idle-party-rpg/shared';
 import { PlayerSession } from './PlayerSession.js';
 import type { GameStateStore, PlayerSaveData } from './GameStateStore.js';
 import { FriendsSystem } from './social/FriendsSystem.js';
@@ -137,6 +137,15 @@ export class PlayerManager {
     for (const ws of wsSet) {
       if (ws.readyState === WebSocket.OPEN) ws.send(payload);
     }
+  }
+
+  /** Broadcast a global welcome message when a new player picks their class. */
+  broadcastWelcome(username: string, className: ClassName): void {
+    const icon = CLASS_ICONS[className] ?? '';
+    const text = `Welcome our new ${className}, ${username}, to the world! ${icon}`;
+    const recipients = this.getOnlinePlayers()
+      .map(u => ({ username: u, send: (m: ChatMessage) => this.sendChatToPlayer(u, m) }));
+    this.chat.sendMessage('Server', 'global', 'global', text, recipients, this.getAllBlockedUsers());
   }
 
   /** Get all blocked users map for chat filtering. */

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -256,6 +256,8 @@ wss.on('connection', (ws) => {
           playerManager.partyBattles.restartBattle(classPartyId);
         }
         playerManager.sendStateToPlayer(username);
+        // Broadcast welcome message to all online players
+        playerManager.broadcastWelcome(username, msg.className as ClassName);
         return;
       }
 


### PR DESCRIPTION
## Summary
- When a new player picks their class, a global chat message is broadcast to all online players: "Welcome our new Archer, SuperPlayer, to the world! 🏹"
- Message is sent from "Server" on the global channel, so everyone online sees it
- Uses the existing chat infrastructure — no new message types needed

Closes #50

## Test plan
- [ ] Create a new account and pick a class — verify all online players see the welcome message in global chat
- [ ] Verify the message includes the correct class name and icon
- [ ] Verify the message appears in chat history for all recipients

🤖 Generated with [Claude Code](https://claude.com/claude-code)