### PR TITLE
Fix clicking own name on sent DMs to open DM with recipient

### DIFF
--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -128,6 +128,12 @@ export class SocialScreen implements Screen {
           this.showUserPopup(username, nameEl);
           return;
         }
+        // Clicking own name on a DM you sent → start DM with the recipient
+        const dmTarget = nameEl.getAttribute('data-dm-target');
+        if (username && dmTarget) {
+          this.startDm(dmTarget);
+          return;
+        }
       }
 
       const btn = target.closest('button') as HTMLButtonElement | null;
@@ -860,14 +866,16 @@ export class SocialScreen implements Screen {
     const ch = SocialScreen.CHAT_CHANNELS.find(c => c.type === msg.channelType);
     const tag = ch?.tag ?? '?';
     const selfName = this.lastState?.username ?? '';
-    const dmTo = (msg.channelType === 'dm' && msg.senderUsername === selfName)
+    const isSelfDm = msg.channelType === 'dm' && msg.senderUsername === selfName;
+    const dmTo = isSelfDm
       ? ` <span class="chat-dm-to">to ${this.escapeHtml(msg.channelId)}</span>` : '';
+    const dmTargetAttr = isSelfDm ? ` data-dm-target="${this.escapeHtml(msg.channelId)}"` : '';
     const time = SocialScreen.formatTimestamp(msg.timestamp);
     const dateFull = SocialScreen.formatDateFull(msg.timestamp);
     return `<div class="social-chat-msg">
       <span class="chat-timestamp" title="${dateFull}">${time}</span>
       <span class="chat-tag chat-color-${msg.channelType} chat-clickable" data-switch-channel="${msg.channelType}">[${tag}]</span>
-      <span class="social-chat-sender chat-color-${msg.channelType} social-user-name-clickable" data-username="${this.escapeHtml(msg.senderUsername)}" data-dm-user="${this.escapeHtml(msg.senderUsername)}">${this.classIcon(this.getPlayerClassName(msg.senderUsername))} ${this.escapeHtml(msg.senderUsername)}${dmTo}</span>
+      <span class="social-chat-sender chat-color-${msg.channelType} social-user-name-clickable" data-username="${this.escapeHtml(msg.senderUsername)}"${dmTargetAttr}>${this.classIcon(this.getPlayerClassName(msg.senderUsername))} ${this.escapeHtml(msg.senderUsername)}${dmTo}</span>
       <span class="social-chat-text">${this.escapeHtml(msg.text)}</span>
     </div>`;
   }


### PR DESCRIPTION
## Summary
- Fixes clicking your own username on a DM you sent — now opens a DM with the recipient instead of doing nothing
- Adds `data-dm-target` attribute to sender span for self-sent DMs, and a fallthrough in the click handler to call `startDm()` with the recipient

Closes #42

## Test plan
- [ ] Send a DM to another player
- [ ] Click your own username on the sent DM message
- [ ] Verify it opens a DM conversation with the recipient
- [ ] Verify clicking other players' names still opens the popup menu as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)