### PR TITLE
Fix map not loading for new players after class selection

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -206,13 +206,9 @@ export class App {
   private async connectAndEnterGame(): Promise<void> {
     this.gameClient = new GameClient();
 
-    // Load world data (per-player filtered) and connect WS in parallel
-    const [connectResult] = await Promise.all([
-      this.gameClient.connect(),
-      this.worldCache.loadWorld().catch(err => {
-        console.warn('[App] Failed to load world data:', err);
-      }),
-    ]);
+    // Connect WS first (creates PlayerSession server-side), then load world data
+    // (world endpoint requires the player session to exist)
+    const connectResult = await this.gameClient.connect();
 
     if (!connectResult.success) {
       if (connectResult.error === CONNECTION_ERROR) {
@@ -222,6 +218,11 @@ export class App {
       this.screenManager.switchTo('login');
       return;
     }
+
+    // Load world data now that the player session exists server-side
+    await this.worldCache.loadWorld().catch(err => {
+      console.warn('[App] Failed to load world data:', err);
+    });
 
     // Check if player needs to select a class (new player or reset Adventurer)
     if (this.gameClient.lastState?.character.className === 'Adventurer') {


### PR DESCRIPTION
## Summary
- Fixed race condition where `/api/world` was called in parallel with the WebSocket connection, but the endpoint requires a `PlayerSession` to exist server-side
- For new players, the session isn't created until the WS `connect()` completes, so `loadWorld()` would 404 and silently fail — leaving the map empty until a refresh
- Changed to sequential: connect first (creates session), then load world data

Closes #61

## Test plan
- [ ] Create a new account and select a class — map should load without needing a refresh
- [ ] Verify existing/returning players still load the map correctly
- [ ] Check that the world data loads after reconnecting from the offline screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)