### PR TITLE
Gray out party invite button, fix stale same-room check

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -296,8 +296,8 @@ export class App {
     const settingsScreen = new PlaceholderScreen('screen-settings', 'Settings', '⚙');
 
     // Wire map username click to social screen popup
-    mapScreen.setOnUserClick((username, anchor) => {
-      socialScreen.showUserPopup(username, anchor);
+    mapScreen.setOnUserClick((username, anchor, tileCol, tileRow) => {
+      socialScreen.showUserPopup(username, anchor, tileCol, tileRow);
     });
 
     // Listen for world content updates (admin deployed a new version)

--- a/client/src/screens/MapScreen.ts
+++ b/client/src/screens/MapScreen.ts
@@ -12,7 +12,7 @@ export class MapScreen implements Screen {
   private sceneReady = false;
   private zoomControls?: HTMLElement;
   private tileModal?: TileInfoModal;
-  private onUserClickCallback?: (username: string, anchor: HTMLElement) => void;
+  private onUserClickCallback?: (username: string, anchor: HTMLElement, tileCol?: number, tileRow?: number) => void;
   private moveToastTimeout?: ReturnType<typeof setTimeout>;
 
   constructor(containerId: string, gameClient: GameClient, worldCache: WorldCache) {
@@ -23,7 +23,7 @@ export class MapScreen implements Screen {
     this.worldCache = worldCache;
   }
 
-  setOnUserClick(cb: (username: string, anchor: HTMLElement) => void): void {
+  setOnUserClick(cb: (username: string, anchor: HTMLElement, tileCol?: number, tileRow?: number) => void): void {
     this.onUserClickCallback = cb;
   }
 
@@ -138,7 +138,7 @@ export class MapScreen implements Screen {
       this.tileModal = new TileInfoModal(
         this.container,
         (col, row) => { this.tryMove(col, row); },
-        (username, anchor) => { this.onUserClickCallback?.(username, anchor); },
+        (username, anchor, tileCol, tileRow) => { this.onUserClickCallback?.(username, anchor, tileCol, tileRow); },
       );
       scene.setOnTileClick((tileInfo) => {
         this.tileModal!.show(tileInfo);

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -560,7 +560,7 @@ export class SocialScreen implements Screen {
 
   // ── User Popup Menu ──────────────────────────────────────────
 
-  showUserPopup(username: string, anchor: HTMLElement): void {
+  showUserPopup(username: string, anchor: HTMLElement, tileCol?: number, tileRow?: number): void {
     this.dismissPopup();
 
     const social = this.lastSocial;
@@ -578,7 +578,10 @@ export class SocialScreen implements Screen {
     const otherPlayers = this.lastState?.otherPlayers ?? [];
     const myCol = this.lastState?.party.col;
     const myRow = this.lastState?.party.row;
-    const sameRoom = otherPlayers.some(p => p.username === username && p.col === myCol && p.row === myRow);
+    // If opened from tile modal, use tile coords for a reliable same-room check
+    const sameRoom = tileCol !== undefined && tileRow !== undefined
+      ? (myCol === tileCol && myRow === tileRow)
+      : otherPlayers.some(p => p.username === username && p.col === myCol && p.row === myRow);
 
     // Build header with relationship labels
     const isFriend = friends.has(username);
@@ -617,7 +620,18 @@ export class SocialScreen implements Screen {
 
     // Party invite — only show if not already in party
     if (!isPartyMember) {
-      if (!sameRoom) {
+      const selfMember = social.party?.members.find(m => m.username === selfUsername);
+      const isLeaderOrOwner = selfMember?.role === 'owner' || selfMember?.role === 'leader';
+      const partyFull = (social.party?.members.length ?? 1) >= MAX_PARTY_SIZE;
+      const alreadyInvited = (social.outgoingPartyInvites ?? []).includes(username);
+
+      if (!isLeaderOrOwner) {
+        items.push(`<button class="user-popup-item disabled" disabled title="Only the party owner or a leader can invite">Invite to Party</button>`);
+      } else if (partyFull) {
+        items.push(`<button class="user-popup-item disabled" disabled title="Party is full (${MAX_PARTY_SIZE}/${MAX_PARTY_SIZE})">Invite to Party</button>`);
+      } else if (alreadyInvited) {
+        items.push(`<button class="user-popup-item disabled" disabled title="Already invited to your party">Invited to Party</button>`);
+      } else if (!sameRoom) {
         items.push(`<button class="user-popup-item disabled" disabled title="You must be in the same room to invite a player to your party">Invite to Party</button>`);
       } else {
         items.push(`<button class="user-popup-item" data-popup-action="party_invite">Invite to Party</button>`);

--- a/client/src/ui/TileInfoModal.ts
+++ b/client/src/ui/TileInfoModal.ts
@@ -5,12 +5,12 @@ export class TileInfoModal {
   private overlay: HTMLElement;
   private modal: HTMLElement;
   private onMove: (col: number, row: number) => void;
-  private onUserClick?: (username: string, anchor: HTMLElement) => void;
+  private onUserClick?: (username: string, anchor: HTMLElement, tileCol: number, tileRow: number) => void;
 
   constructor(
     parent: HTMLElement,
     onMove: (col: number, row: number) => void,
-    onUserClick?: (username: string, anchor: HTMLElement) => void,
+    onUserClick?: (username: string, anchor: HTMLElement, tileCol: number, tileRow: number) => void,
   ) {
     this.onMove = onMove;
     this.onUserClick = onUserClick;
@@ -92,7 +92,7 @@ export class TileInfoModal {
       el.addEventListener('click', () => {
         const username = el.getAttribute('data-username');
         if (username && this.onUserClick) {
-          this.onUserClick(username, el as HTMLElement);
+          this.onUserClick(username, el as HTMLElement, info.col, info.row);
         }
       });
     }


### PR DESCRIPTION
## Summary
- **Invite to Party** button in the user popup is now grayed out with a tooltip when: the player is not owner/leader, party is full (5/5), or an invite was already sent to that player
- Fixed a bug where walking into a room on the map required switching tabs before you could invite other players — tile coordinates are now passed from TileInfoModal directly to the same-room check

## Test plan
- [ ] As a party member (not leader/owner), open popup on another player — "Invite to Party" should be grayed out with "Only the party owner or a leader can invite" tooltip
- [ ] With a full party (5/5), open popup — should show "Party is full (5/5)" tooltip
- [ ] After sending an invite, re-open popup on same player — should show "Invited to Party" (disabled)
- [ ] Walk to a room with other players, immediately click a player in the tile modal — invite should be available without needing to switch tabs
- [ ] Verify existing same-room check still works from the Social tab Users list

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)