### PR TITLE
Fix social panel not rendering on initial activation

### DIFF
--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -97,7 +97,17 @@ export class SocialScreen implements Screen {
       }
     });
     const state = this.gameClient.lastState;
-    if (state) this.updateFromState(state);
+    if (state) {
+      this.lastSocial = state.social ?? null;
+      this.lastState = state;
+      if (!this.chatPrefsInitialized && state.social?.chatPreferences) {
+        this.chatSendChannel = state.social.chatPreferences.sendChannel;
+        this.chatDmTarget = state.social.chatPreferences.dmTarget;
+        this.chatPrefsInitialized = true;
+      }
+      this.renderTabBar();
+      this.renderPanel();
+    }
   }
 
   onDeactivate(): void {


### PR DESCRIPTION
## Summary
- Fix regression from #68 where Social sub-tabs (Users, Chat, etc.) showed empty content on page refresh until the user switched sub-tabs
- `onActivate()` now does a full `renderPanel()` with the initial state to populate the DOM, then subsequent ticks use targeted update methods

## Test plan
- [ ] Refresh page while on Social > Users — content loads immediately
- [ ] Refresh page while on Social > Chat — messages and input bar load immediately
- [ ] Refresh page while on Social > Party — grid and members load immediately
- [ ] Refresh page while on Social > Guild — guild info loads immediately
- [ ] Verify clicks still work reliably during combat ticks (no regression from #68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)