### PR TITLE
Fix stale chat on tab resume

### DIFF
--- a/client/src/network/GameClient.ts
+++ b/client/src/network/GameClient.ts
@@ -9,6 +9,7 @@ type ConnectionListener = (connected: boolean) => void;
 type WorldUpdateListener = () => void;
 type EquipBlockedListener = (msg: ServerEquipBlockedMessage) => void;
 type SuspensionListener = () => void;
+type ResumeListener = () => void;
 
 export class GameClient {
   private ws: WebSocket | null = null;
@@ -24,6 +25,7 @@ export class GameClient {
   private worldUpdateListeners = new Set<WorldUpdateListener>();
   private equipBlockedListeners = new Set<EquipBlockedListener>();
   private suspensionListeners = new Set<SuspensionListener>();
+  private resumeListeners = new Set<ResumeListener>();
 
   /** Pending connect resolve — set during connect() call. */
   private connectResolve?: (result: { success: boolean; error?: string }) => void;
@@ -48,6 +50,9 @@ export class GameClient {
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
         this.isInitialState = true;
+        for (const listener of this.resumeListeners) {
+          listener();
+        }
         if (this.ws?.readyState === WebSocket.OPEN) {
           this.sendRaw({ type: 'request_state' });
         } else if (this.connected && !this.destroyed) {
@@ -92,6 +97,12 @@ export class GameClient {
   onSuspension(listener: SuspensionListener): () => void {
     this.suspensionListeners.add(listener);
     return () => { this.suspensionListeners.delete(listener); };
+  }
+
+  /** Subscribe to tab resume (visibilitychange → visible). Returns an unsubscribe function. */
+  onResume(listener: ResumeListener): () => void {
+    this.resumeListeners.add(listener);
+    return () => { this.resumeListeners.delete(listener); };
   }
 
   private doConnect(): void {
@@ -376,5 +387,6 @@ export class GameClient {
     this.chatListeners.clear();
     this.chatHistoryListeners.clear();
     this.worldUpdateListeners.clear();
+    this.resumeListeners.clear();
   }
 }

--- a/client/src/screens/SettingsScreen.ts
+++ b/client/src/screens/SettingsScreen.ts
@@ -2,6 +2,12 @@ import type { Screen } from './ScreenManager';
 
 const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.03.24.2',
+    notes: [
+      'Fixed chat not refreshing when resuming from a backgrounded tab — chat history is now re-fetched on resume',
+    ],
+  },
+  {
     version: '2026.03.24.1',
     notes: [
       'Added Settings screen with Patch Notes viewer',

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -63,6 +63,15 @@ export class SocialScreen implements Screen {
     this.container = el;
     this.gameClient = gameClient;
     this.buildDOM();
+
+    // On tab resume, clear cached chat so history is re-fetched with fresh data
+    this.gameClient.onResume(() => {
+      this.chatHistoryLoaded.clear();
+      this.chatMessages = [];
+      if (this.isActive && this.activeTab === 'chat') {
+        this.renderChatPanel();
+      }
+    });
   }
 
   onActivate(): void {


### PR DESCRIPTION
## Summary
- Adds an `onResume` event to `GameClient` that fires when the browser tab becomes visible again
- `SocialScreen` listens for resume and clears its cached chat history + messages, forcing a fresh re-fetch from the server
- Chat messages received while the app was backgrounded are now properly loaded on return

## Root cause
When a user backgrounds the app and returns, `request_state` is sent but `ServerStateMessage` doesn't include chat history. Chat is pull-based (requires explicit `request_chat_history` requests), but the `chatHistoryLoaded` cache prevented re-fetching. Messages received while backgrounded were lost.

## Test plan
- [x] `npm run build` passes (client — server has pre-existing unrelated type error)
- [x] All 228 tests pass
- [ ] Manual: open app on phone, send chat messages from another device while app is backgrounded, resume and verify messages appear

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)