### PR TITLE
Fix combat log skipping updates on same-type monster kills

### DIFF
--- a/client/src/screens/CombatScreen.ts
+++ b/client/src/screens/CombatScreen.ts
@@ -16,8 +16,8 @@ export class CombatScreen implements Screen {
   private enemySide!: HTMLElement;
   private logContainer!: HTMLElement;
 
-  // Last rendered log length — for incremental DOM updates
-  private renderedLogLength = 0;
+  // Last rendered log entry ID — for incremental DOM updates
+  private lastRenderedId = -1;
   private lastLog: CombatLogEntry[] = [];
   private renderedPlayerKey = '';
   private renderedEnemyKey = '';
@@ -43,7 +43,7 @@ export class CombatScreen implements Screen {
     }
 
     // Full re-render of log on activate (may have accumulated while inactive)
-    this.renderedLogLength = 0;
+    this.lastRenderedId = -1;
     this.renderLog(this.lastLog);
   }
 
@@ -270,28 +270,33 @@ export class CombatScreen implements Screen {
   }
 
   private updateLog(log: CombatLogEntry[]): void {
-    if (log.length < this.renderedLogLength) {
-      // Log was trimmed (entries shifted off the front) — full re-render
+    const lastId = log.length > 0 ? log[log.length - 1].id : -1;
+
+    // Nothing new — skip
+    if (lastId === this.lastRenderedId) return;
+
+    // Find the first entry we haven't rendered yet
+    const startIdx = log.findIndex(e => e.id > this.lastRenderedId);
+
+    if (startIdx <= 0) {
+      // Log reset or all entries are new — full re-render
       this.renderLog(log);
-      return;
-    }
-
-    if (log.length === this.renderedLogLength) {
-      // Same length — check if entries cycled (log at max capacity:
-      // server shifts old entries off the front, pushes new to the back)
-      const lastRendered = this.logContainer.lastElementChild;
-      const lastEntry = log[log.length - 1];
-      if (lastEntry && lastRendered && lastRendered.textContent !== lastEntry.text) {
-        this.renderLog(log);
+    } else {
+      // Trim DOM if old entries shifted off the front (log at max capacity)
+      const staleCount = this.logContainer.childElementCount - (log.length - startIdx) - startIdx;
+      if (staleCount > 0) {
+        // Old entries at the front are no longer in the log — remove them
+        for (let i = 0; i < staleCount && this.logContainer.firstChild; i++) {
+          this.logContainer.removeChild(this.logContainer.firstChild);
+        }
       }
-      return;
-    }
 
-    // Append only new entries
-    for (let i = this.renderedLogLength; i < log.length; i++) {
-      this.appendLogEntry(log[i]);
+      // Append only new entries
+      for (let i = startIdx; i < log.length; i++) {
+        this.appendLogEntry(log[i]);
+      }
+      this.lastRenderedId = lastId;
     }
-    this.renderedLogLength = log.length;
   }
 
   private renderLog(log: CombatLogEntry[]): void {
@@ -299,7 +304,7 @@ export class CombatScreen implements Screen {
     for (const entry of log) {
       this.appendLogEntry(entry);
     }
-    this.renderedLogLength = log.length;
+    this.lastRenderedId = log.length > 0 ? log[log.length - 1].id : -1;
   }
 
   private appendLogEntry(entry: CombatLogEntry): void {

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -62,6 +62,7 @@ export class PlayerSession {
   private content: ContentStore;
   private unlockSystem: UnlockSystem;
   private combatLog: CombatLogEntry[] = [];
+  private logIdCounter = 0;
   private battleCount = 0;
   private character: CharacterState;
   private chatHistory: ChatMessage[] = [];
@@ -394,7 +395,7 @@ export class PlayerSession {
   }
 
   addLogEntry(text: string, type: CombatLogEntry['type']): void {
-    this.combatLog.push({ text, type });
+    this.combatLog.push({ id: ++this.logIdCounter, text, type });
     if (this.combatLog.length > MAX_LOG_ENTRIES) {
       this.combatLog.shift();
     }
@@ -424,6 +425,7 @@ export class PlayerSession {
 
     this.battleCount = 0;
     this.combatLog = [];
+    this.logIdCounter = 0;
     this.unlockSystem = new UnlockSystem(this.grid, startTile);
     this.partyId = null;
 
@@ -498,7 +500,15 @@ export class PlayerSession {
     session['grid'] = grid;
     session['content'] = content;
     session['battleCount'] = data.battleCount;
-    session['combatLog'] = data.combatLog.slice(-MAX_LOG_ENTRIES);
+    // Migrate old log entries without IDs and restore the counter
+    const restoredLog = data.combatLog.slice(-MAX_LOG_ENTRIES);
+    let maxId = 0;
+    for (const entry of restoredLog) {
+      if (!entry.id) entry.id = ++maxId;
+      else if (entry.id > maxId) maxId = entry.id;
+    }
+    session['combatLog'] = restoredLog;
+    session['logIdCounter'] = maxId;
     // Migrate old cube-key-based unlocks ("q,r,s") to tile GUIDs
     let unlockedKeys = data.unlockedKeys;
     if (unlockedKeys.length > 0 && unlockedKeys[0].split(',').length === 3) {

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -114,6 +114,7 @@ export interface OtherPlayerState {
 export type CombatLogType = 'battle' | 'victory' | 'defeat' | 'move' | 'unlock' | 'damage' | 'levelup';
 
 export interface CombatLogEntry {
+  id: number;
   text: string;
   type: CombatLogType;
 }


### PR DESCRIPTION
## Summary
- Combat log updates were silently skipped when consecutive ticks killed monsters of the same type (e.g., two Goblins), because the change detection compared only the last entry's text (`"Goblin defeated!"` === `"Goblin defeated!"`)
- Added monotonic `id` field to `CombatLogEntry` — server assigns via `++logIdCounter` in `addLogEntry()`
- Client now tracks `lastRenderedId` instead of `renderedLogLength`, using the ID to detect new entries, append incrementally, and trim stale DOM nodes
- Old saves without IDs are migrated on restore

## Test plan
- [ ] Join a 4-player party and fight groups of same-type monsters (e.g., all Goblins) — verify each player's hit/kill shows in the combat log immediately, not batched
- [ ] Verify combat log still works correctly for single-player parties
- [ ] Restart the server with existing save data — verify old log entries display correctly (migration)
- [ ] Switch tabs away and back — verify log re-renders fully on activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)