### PR TITLE
Fix item duplication exploit in equipment system

### DIFF
--- a/client/src/screens/SettingsScreen.ts
+++ b/client/src/screens/SettingsScreen.ts
@@ -2,6 +2,14 @@ import type { Screen } from './ScreenManager';
 
 const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.03.24.3',
+    notes: [
+      'Fixed item duplication exploit — equipping two-handed weapons with a full offhand stack no longer duplicates the mainhand item',
+      'Fixed stale two-handed weapon state — unequipping a weapon that occupies both slots now always clears both slots correctly',
+      'Added equipment slot validation to prevent items from being equipped into invalid slots',
+    ],
+  },
+  {
     version: '2026.03.24.2',
     notes: [
       'Fixed chat not refreshing when resuming from a backgrounded tab — chat history is now re-fetched on resume',

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -547,7 +547,7 @@ export class PlayerSession {
         inventory: data.character.inventory ? { ...data.character.inventory } : {},
         equipment: data.character.equipment
           ? { ...data.character.equipment }
-          : { head: null, chest: null, hand: null, foot: null },
+          : { head: null, shoulders: null, chest: null, bracers: null, gloves: null, mainhand: null, offhand: null, foot: null, ring: null, necklace: null, back: null, relic: null },
         skillLoadout,
         skillPoints,
       };

--- a/shared/src/systems/CharacterStats.ts
+++ b/shared/src/systems/CharacterStats.ts
@@ -129,7 +129,7 @@ export function createDefaultCharacter(): CharacterState {
     xp: 0,
     gold: 0,
     inventory: {},
-    equipment: { head: null, chest: null, hand: null, foot: null },
+    equipment: { head: null, shoulders: null, chest: null, bracers: null, gloves: null, mainhand: null, offhand: null, foot: null, ring: null, necklace: null, back: null, relic: null },
     skillLoadout: { unlockedSkills: [], equippedSkills: [null, null, null] },
     skillPoints: 0,
   };
@@ -143,7 +143,7 @@ export function createCharacter(className: ClassName): CharacterState {
     xp: 0,
     gold: 0,
     inventory: {},
-    equipment: { head: null, chest: null, hand: null, foot: null },
+    equipment: { head: null, shoulders: null, chest: null, bracers: null, gloves: null, mainhand: null, offhand: null, foot: null, ring: null, necklace: null, back: null, relic: null },
     skillLoadout: createDefaultSkillLoadout(className),
     skillPoints: 0,
   };

--- a/shared/src/systems/ItemTypes.ts
+++ b/shared/src/systems/ItemTypes.ts
@@ -283,26 +283,43 @@ export function equipItem(
 
   const slot = def.equipSlot;
 
-  // If a 2H weapon is currently equipped and we're touching mainhand or offhand, unequip it first
-  if ((slot === 'mainhand' || slot === 'offhand') && isTwoHandedEquipped(equipment, items)) {
+  // Validate slot is a known equip slot
+  if (!EQUIP_SLOTS.includes(slot)) return { success: false };
+
+  const replacing2H = (slot === 'mainhand' || slot === 'offhand') && isTwoHandedEquipped(equipment, items);
+
+  // --- Pre-check: ensure all inventory returns will succeed BEFORE mutating ---
+  if (replacing2H) {
     const twoHandId = equipment.mainhand!;
-    if (!addItemToInventory(inventory, twoHandId)) return { success: false };
+    if ((inventory[twoHandId] ?? 0) >= MAX_STACK) return { success: false };
+  } else {
+    const currentEquipped = equipment[slot];
+    if (currentEquipped && (inventory[currentEquipped] ?? 0) >= MAX_STACK) return { success: false };
+    // If equipping a 2H, also need to return offhand
+    if (def.twoHanded) {
+      const offhandItem = equipment.offhand;
+      if (offhandItem && (inventory[offhandItem] ?? 0) >= MAX_STACK) return { success: false };
+    }
+  }
+
+  // --- All checks passed, now mutate ---
+  if (replacing2H) {
+    const twoHandId = equipment.mainhand!;
+    addItemToInventory(inventory, twoHandId);
     equipment.mainhand = null;
     equipment.offhand = null;
-    // Now proceed to equip the new item into the target slot
   } else {
     // Normal case: if slot is occupied, return old item to inventory
     const currentEquipped = equipment[slot];
     if (currentEquipped) {
-      if (!addItemToInventory(inventory, currentEquipped)) return { success: false };
+      addItemToInventory(inventory, currentEquipped);
     }
-  }
-
-  // If equipping a 2H weapon, also clear offhand (return to inventory if occupied)
-  if (def.twoHanded) {
-    const offhandItem = equipment.offhand;
-    if (offhandItem) {
-      if (!addItemToInventory(inventory, offhandItem)) return { success: false };
+    // If equipping a 2H weapon, also clear offhand (return to inventory if occupied)
+    if (def.twoHanded) {
+      const offhandItem = equipment.offhand;
+      if (offhandItem) {
+        addItemToInventory(inventory, offhandItem);
+      }
     }
   }
 
@@ -320,6 +337,8 @@ export function equipItem(
  * Unequip an item from a slot back to inventory.
  * Returns { success: true, itemId } on success.
  * If a 2H weapon is equipped, clicking either mainhand or offhand unequips both.
+ * Also handles stale 2H state: if mainhand and offhand hold the same item ID,
+ * treat it as a 2H weapon regardless of current item definition.
  */
 export function unequipItem(
   inventory: Record<string, number>,
@@ -330,8 +349,12 @@ export function unequipItem(
   const equipped = equipment[slot];
   if (!equipped) return { success: false };
 
-  // Check if this is a 2H weapon (same item in both mainhand and offhand)
-  if ((slot === 'mainhand' || slot === 'offhand') && items && isTwoHandedEquipped(equipment, items)) {
+  // Detect 2H: either by item definition or by same item in both mainhand+offhand (stale 2H state)
+  const is2H = (slot === 'mainhand' || slot === 'offhand') && equipment.mainhand != null
+    && equipment.mainhand === equipment.offhand;
+  const is2HByDef = (slot === 'mainhand' || slot === 'offhand') && items && isTwoHandedEquipped(equipment, items);
+
+  if (is2H || is2HByDef) {
     const twoHandId = equipment.mainhand!;
     if ((inventory[twoHandId] ?? 0) >= MAX_STACK) return { success: false };
     addItemToInventory(inventory, twoHandId);
@@ -445,6 +468,9 @@ export function equipItemForceDestroy(
   if ((inventory[itemId] ?? 0) <= 0) return { success: false };
 
   const slot = def.equipSlot;
+
+  // Validate slot is a known equip slot
+  if (!EQUIP_SLOTS.includes(slot)) return { success: false };
 
   // If a 2H is equipped and we're touching mainhand/offhand, destroy the 2H and clear both slots
   if ((slot === 'mainhand' || slot === 'offhand') && isTwoHandedEquipped(equipment, items)) {

--- a/shared/tests/ItemTypes.test.ts
+++ b/shared/tests/ItemTypes.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   destroyItems,
+  equipItem,
   equipItemForceDestroy,
+  unequipItem,
   MAX_STACK,
   SEED_ITEMS,
 } from '../src/systems/ItemTypes';
@@ -94,5 +96,95 @@ describe('equipItemForceDestroy', () => {
 
     const result = equipItemForceDestroy(inv, equip, 'rusty_dagger', SEED_ITEMS);
     expect(result).toEqual({ success: false });
+  });
+});
+
+describe('equipItem - duplication prevention', () => {
+  const items: Record<string, ItemDefinition> = {
+    ...SEED_ITEMS,
+    big_rock: { id: 'big_rock', name: 'Big Rock', rarity: 'common', equipSlot: 'mainhand' as EquipSlot, twoHanded: true },
+    small_shield: { id: 'small_shield', name: 'Small Shield', rarity: 'common', equipSlot: 'offhand' as EquipSlot },
+  };
+
+  it('does not duplicate mainhand item when equipping 2H fails due to full offhand stack', () => {
+    const inv: Record<string, number> = { big_rock: 1, small_shield: MAX_STACK };
+    const equip: Record<string, string | null> = {
+      mainhand: 'rusty_dagger',
+      offhand: 'small_shield',
+      head: null, chest: null, foot: null,
+    };
+
+    // Equipping 2H big_rock should fail because small_shield is at MAX_STACK
+    const result = equipItem(inv, equip, 'big_rock', items);
+    expect(result.success).toBe(false);
+
+    // CRITICAL: mainhand item must NOT be duplicated in inventory
+    expect(inv['rusty_dagger']).toBeUndefined();
+    expect(equip.mainhand).toBe('rusty_dagger');
+    expect(equip.offhand).toBe('small_shield');
+    // big_rock should still be in inventory untouched
+    expect(inv['big_rock']).toBe(1);
+  });
+
+  it('correctly equips 2H weapon when both slots can be returned', () => {
+    const inv: Record<string, number> = { big_rock: 1 };
+    const equip: Record<string, string | null> = {
+      mainhand: 'rusty_dagger',
+      offhand: 'small_shield',
+      head: null, chest: null, foot: null,
+    };
+
+    const result = equipItem(inv, equip, 'big_rock', items);
+    expect(result.success).toBe(true);
+    expect(equip.mainhand).toBe('big_rock');
+    expect(equip.offhand).toBe('big_rock');
+    expect(inv['rusty_dagger']).toBe(1);
+    expect(inv['small_shield']).toBe(1);
+    expect(inv['big_rock']).toBeUndefined();
+  });
+
+  it('rejects items with invalid equipSlot', () => {
+    const badItems: Record<string, ItemDefinition> = {
+      fake: { id: 'fake', name: 'Fake', rarity: 'common', equipSlot: 'bogus' as EquipSlot },
+    };
+    const inv: Record<string, number> = { fake: 1 };
+    const equip: Record<string, string | null> = { mainhand: null };
+
+    const result = equipItem(inv, equip, 'fake', badItems);
+    expect(result.success).toBe(false);
+    expect(inv['fake']).toBe(1);
+  });
+});
+
+describe('unequipItem - stale 2H state', () => {
+  it('treats same item in both mainhand and offhand as 2H even without definition', () => {
+    const inv: Record<string, number> = {};
+    const equip: Record<string, string | null> = {
+      mainhand: 'old_weapon',
+      offhand: 'old_weapon',
+      head: null, chest: null, foot: null,
+    };
+
+    // Unequip mainhand — should clear BOTH slots and return only 1 copy
+    const result = unequipItem(inv, equip, 'mainhand');
+    expect(result.success).toBe(true);
+    expect(result.itemId).toBe('old_weapon');
+    expect(equip.mainhand).toBeNull();
+    expect(equip.offhand).toBeNull();
+    expect(inv['old_weapon']).toBe(1);
+  });
+
+  it('prevents double-counting when unequipping offhand of stale 2H', () => {
+    const inv: Record<string, number> = {};
+    const equip: Record<string, string | null> = {
+      mainhand: 'old_weapon',
+      offhand: 'old_weapon',
+    };
+
+    const result = unequipItem(inv, equip, 'offhand');
+    expect(result.success).toBe(true);
+    expect(equip.mainhand).toBeNull();
+    expect(equip.offhand).toBeNull();
+    expect(inv['old_weapon']).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Fixed item duplication exploit where equipping a 2H weapon with a full offhand stack duplicated the mainhand item in inventory (unlimited copies per attempt)
- Fixed stale 2H weapon state: unequipping a weapon that sits in both mainhand and offhand now always clears both slots, even if the item definition changed
- Added `EQUIP_SLOTS` validation in `equipItem`/`equipItemForceDestroy` to reject items with invalid slot definitions
- Fixed default equipment initialization to include all 12 valid slots instead of 4 legacy ones

## Test plan
- [x] Added tests for the duplication bug (equipping 2H with full offhand stack)
- [x] Added tests for stale 2H unequip (same item in both slots without definition)
- [x] Added test for invalid equipSlot rejection
- [x] All 188 shared tests pass
- [x] Typecheck passes
- [x] Full build succeeds

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)