### PR TITLE
Improve ban system and add startup timing

### DIFF
--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -131,7 +131,8 @@ export class AdminApp {
   private accounts: AccountData[] = [];
   private accountSortColumn: AccountSortColumn = 'lastActive';
   private accountSortDir: SortDirection = 'desc';
-  private accountFilterHideNoChar = false;
+  private accountFilterShowNoChar = false;
+  private accountFilterShowBanned = false;
   private accountFilterActiveDays = '';
   private accountFilterCreatedDays = '';
   private duplicateTokens: Record<string, string[]> = {}; // deviceToken → emails
@@ -446,8 +447,12 @@ export class AdminApp {
   private getFilteredAccounts(): AccountData[] {
     let filtered = [...this.accounts];
 
-    if (this.accountFilterHideNoChar) {
+    if (!this.accountFilterShowNoChar) {
       filtered = filtered.filter(a => a.username && a.className && a.className !== 'Adventurer');
+    }
+
+    if (!this.accountFilterShowBanned) {
+      filtered = filtered.filter(a => !a.deactivated);
     }
 
     const activeDays = parseInt(this.accountFilterActiveDays);
@@ -542,10 +547,10 @@ export class AdminApp {
         statusBadges.push('<span class="status-offline">Offline</span>');
       }
       if (a.deactivated) {
-        statusBadges.push('<span style="color: #e74c3c; font-weight: bold; margin-left: 4px;" title="Suspended">BAN</span>');
-      }
-      if (a.hasReactivationRequest) {
-        statusBadges.push('<span style="color: #f39c12; margin-left: 4px;" title="Has reactivation request">REQ</span>');
+        const appealIcon = a.hasReactivationRequest
+          ? ' <span style="color: #f39c12; cursor: help;" title="Has reactivation request">💬</span>'
+          : '';
+        statusBadges.push(`<span style="color: #e74c3c; font-weight: bold; margin-left: 4px;" title="Suspended">BAN${appealIcon}</span>`);
       }
 
       return `
@@ -566,8 +571,12 @@ export class AdminApp {
         <div class="admin-page-header"><h2>Accounts — Showing ${filteredCount} of ${totalCount}</h2></div>
         <div class="pixel-panel" style="margin-bottom: 12px; padding: 10px; display: flex; flex-wrap: wrap; gap: 12px; align-items: center; font-size: 0.85em;">
           <label style="display: flex; align-items: center; gap: 4px;">
-            <input type="checkbox" id="filter-hide-no-char" ${this.accountFilterHideNoChar ? 'checked' : ''}>
-            Hide no character
+            <input type="checkbox" id="filter-show-no-char" ${this.accountFilterShowNoChar ? 'checked' : ''}>
+            Show no character
+          </label>
+          <label style="display: flex; align-items: center; gap: 4px;">
+            <input type="checkbox" id="filter-show-banned" ${this.accountFilterShowBanned ? 'checked' : ''}>
+            Show banned
           </label>
           <label style="display: flex; align-items: center; gap: 4px;">
             Active in last
@@ -613,8 +622,12 @@ export class AdminApp {
 
   private wireAccountEvents(): void {
     // Filter controls
-    document.getElementById('filter-hide-no-char')?.addEventListener('change', (e) => {
-      this.accountFilterHideNoChar = (e.target as HTMLInputElement).checked;
+    document.getElementById('filter-show-no-char')?.addEventListener('change', (e) => {
+      this.accountFilterShowNoChar = (e.target as HTMLInputElement).checked;
+      this.renderTabContent();
+    });
+    document.getElementById('filter-show-banned')?.addEventListener('change', (e) => {
+      this.accountFilterShowBanned = (e.target as HTMLInputElement).checked;
       this.renderTabContent();
     });
     document.getElementById('filter-active-days')?.addEventListener('input', (e) => {

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -73,7 +73,7 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
     res.json({ duplicates });
   });
 
-  /** Deactivate a player account. Kicks them if online. */
+  /** Deactivate a player account. Fully removes them from the game world. */
   router.post('/players/:username/deactivate', async (req, res) => {
     const { username } = req.params;
     const account = accountStore.findByUsername(username);
@@ -83,7 +83,7 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
     }
     await accountStore.setDeactivated(account.email, true);
     const pm = getPlayerManager();
-    pm.kickPlayer(username);
+    await pm.banPlayer(username);
     console.log(`[Admin] Deactivated "${username}"`);
     res.json({ success: true });
   });

--- a/server/src/game/GameLoop.ts
+++ b/server/src/game/GameLoop.ts
@@ -30,9 +30,16 @@ export class GameLoop {
    * Call once after construction, before accepting connections.
    */
   async init(accountStore: AccountStore): Promise<void> {
+    let t: number;
+
     // Load game content from data/*.json (seeds defaults if files missing)
+    t = performance.now();
     await this.contentStore.load();
+    console.log(`[Startup] ContentStore loaded in ${(performance.now() - t).toFixed(1)}ms`);
+
+    t = performance.now();
     await this.versionStore.load();
+    console.log(`[Startup] VersionStore loaded in ${(performance.now() - t).toFixed(1)}ms`);
 
     // Ensure at least one active version exists (first boot / fresh install)
     if (!this.versionStore.getActiveVersionId()) {
@@ -44,7 +51,9 @@ export class GameLoop {
     }
 
     // Build hex grid from content store world data
+    t = performance.now();
     this.grid = this.buildGridFromContent();
+    console.log(`[Startup] HexGrid built (${this.grid.size} tiles) in ${(performance.now() - t).toFixed(1)}ms`);
 
     // Create player manager now that grid + content are ready
     (this as { playerManager: PlayerManager }).playerManager = new PlayerManager(
@@ -52,16 +61,21 @@ export class GameLoop {
       this.contentStore,
       this.guildStore,
       accountStore,
+      this.store,
     );
 
-    console.log(`[GameLoop] Map: ${this.grid.size} tiles`);
-
+    t = performance.now();
     await this.guildStore.load();
+    console.log(`[Startup] GuildStore loaded in ${(performance.now() - t).toFixed(1)}ms`);
 
+    t = performance.now();
     const saves = await this.store.loadAll();
+    console.log(`[Startup] Save files loaded (${saves.length} players) in ${(performance.now() - t).toFixed(1)}ms`);
+
     if (saves.length > 0) {
-      console.log(`[GameLoop] Found ${saves.length} save file(s): ${saves.map(s => s.username).join(', ')}`);
+      t = performance.now();
       this.playerManager.restoreFromSaveData(saves);
+      console.log(`[Startup] Sessions restored in ${(performance.now() - t).toFixed(1)}ms`);
     } else {
       console.log('[GameLoop] No save files found — fresh start');
     }

--- a/server/src/game/PlayerManager.ts
+++ b/server/src/game/PlayerManager.ts
@@ -20,6 +20,7 @@ export class PlayerManager {
   private grid: HexGrid;
   private content: ContentStore;
   private accountStore: AccountStore;
+  private store: GameStateStore;
   readonly friends: FriendsSystem;
   readonly guilds: GuildSystem;
   readonly chat: ChatSystem;
@@ -28,10 +29,11 @@ export class PlayerManager {
   readonly partyBattles: PartyBattleManager;
   private getAllUsernames: () => string[];
 
-  constructor(grid: HexGrid, content: ContentStore, guildStore: GuildStore, accountStore: AccountStore) {
+  constructor(grid: HexGrid, content: ContentStore, guildStore: GuildStore, accountStore: AccountStore, store: GameStateStore) {
     this.grid = grid;
     this.content = content;
     this.accountStore = accountStore;
+    this.store = store;
     this.friends = new FriendsSystem();
     this.chat = new ChatSystem();
     this.guilds = new GuildSystem(guildStore);
@@ -47,7 +49,7 @@ export class PlayerManager {
     );
   }
 
-  login(ws: WebSocket, username: string): PlayerSession {
+  async login(ws: WebSocket, username: string): Promise<PlayerSession> {
     // Associate this connection with the username
     this.connections.set(ws, username);
 
@@ -64,7 +66,22 @@ export class PlayerManager {
     // Create session if it doesn't exist (or resume existing)
     let session = this.sessions.get(username);
     if (!session) {
-      session = new PlayerSession(username, this.grid, this.content);
+      // Try to load saved data from disk (e.g. unbanned player returning)
+      const saveData = await this.store.load(username);
+      if (saveData) {
+        // Session was not in memory (skipped during restore, e.g. was banned).
+        // Reset position to start tile and clear party state (party not in memory).
+        const startPos = this.content.getStartTile();
+        saveData.position = { col: startPos.col, row: startPos.row };
+        saveData.target = null;
+        saveData.movementQueue = [];
+        saveData.partyId = null;
+        saveData.partyRole = undefined;
+        saveData.partyGridPosition = undefined;
+        session = PlayerSession.fromSaveData(saveData, this.grid, this.content);
+      } else {
+        session = new PlayerSession(username, this.grid, this.content);
+      }
       this.sessions.set(username, session);
       this.friends.initPlayer(username, session.getFriends(), session.getOutgoingFriendRequests());
       this.wireCallbacks(session);
@@ -115,6 +132,64 @@ export class PlayerManager {
       this.playerConnections.delete(username);
     }
     console.log(`[PlayerManager] Kicked "${username}"`);
+  }
+
+  /**
+   * Ban a player: save state, remove from party/combat/map, close connections, delete session.
+   * The player's save data is preserved on disk (frozen at ban time).
+   * Called by admin deactivation — fully vanishes the player from the game.
+   */
+  async banPlayer(username: string, store?: GameStateStore): Promise<void> {
+    const saveStore = store ?? this.store;
+    const session = this.sessions.get(username);
+
+    // Cancel any active trade
+    const cancelledTrade = this.trades.cancelTrade(username, 'Player suspended');
+    if (cancelledTrade) {
+      const partner = cancelledTrade.initiator.username === username
+        ? cancelledTrade.target?.username
+        : cancelledTrade.initiator.username;
+      if (partner) this.sendStateToPlayer(partner);
+    }
+
+    // Save current state before removal (freezes XP/inventory at ban time)
+    if (session) {
+      const partyId = session.getPartyId();
+      const movementData = partyId ? this.partyBattles.getMovementSaveData(partyId) : undefined;
+      let partyInfo: { role: PartyRole; gridPosition: number } | undefined;
+      if (partyId) {
+        const party = this.parties.getParty(partyId);
+        if (party) {
+          const member = party.members.find(m => m.username === username);
+          if (member) partyInfo = { role: member.role, gridPosition: member.gridPosition };
+        }
+      }
+      const saveData = session.toSaveData(movementData ?? undefined, partyInfo);
+      await saveStore.saveAll([saveData]);
+    }
+
+    // Remove from party (and its battle entry)
+    const partyId = session?.getPartyId();
+    if (partyId) {
+      // leaveParty handles both solo (deletes party) and multi-player (transfers ownership)
+      this.parties.leaveParty(
+        username,
+        (u) => this.sessions.get(u)?.getPartyId() ?? null,
+        (u, id) => this.sessions.get(u)?.setPartyId(id),
+      );
+      this.partyBattles.removeMember(partyId, username);
+    }
+
+    // Remove from friends system
+    this.friends.removePlayer(username);
+
+    // Remove session from memory (stops battles, removes from map/player lists)
+    this.sessions.delete(username);
+
+    // Close all WebSocket connections
+    this.kickPlayer(username);
+
+    console.log(`[PlayerManager] Banned "${username}" — session removed, state saved`);
   }
 
   getSession(ws: WebSocket): PlayerSession | undefined {
@@ -255,11 +330,16 @@ export class PlayerManager {
       pendingInvites: this.parties.getPendingInvites(username),
       outgoingPartyInvites: this.parties.getOutgoingInvites(username),
       onlinePlayers: this.getOnlinePlayers(),
-      allPlayers: this.getAllUsernames().map(u => ({
-        username: u,
-        className: this.sessions.get(u)?.getClassName(),
-        level: this.sessions.get(u)?.getLevel(),
-      })),
+      allPlayers: this.getAllUsernames()
+        .filter(u => {
+          const acct = this.accountStore.findByUsername(u);
+          return !acct?.deactivated;
+        })
+        .map(u => ({
+          username: u,
+          className: this.sessions.get(u)?.getClassName(),
+          level: this.sessions.get(u)?.getLevel(),
+        })),
       blockedUsers: session?.getBlockedUsers() ?? {},
       chatPreferences: {
         sendChannel: session?.getChatSendChannel() ?? 'zone',
@@ -429,12 +509,21 @@ export class PlayerManager {
     const startPos = this.content.getStartTile();
     const startCoord = offsetToCube(startPos);
     const startTile = this.grid.getTile(startCoord);
+    let phaseStart: number;
 
     // Phase 1: Restore all sessions
+    phaseStart = performance.now();
     const validSaves: PlayerSaveData[] = [];
     for (const data of saves) {
       if (!data.username || data.username === 'undefined' || !data.position) {
         console.warn(`[PlayerManager] Skipping invalid save data (username="${data.username}", position=${JSON.stringify(data.position)})`);
+        continue;
+      }
+
+      // Skip deactivated (banned) accounts — they should not resume battling
+      const account = this.accountStore.findByUsername(data.username);
+      if (account?.deactivated) {
+        console.log(`[PlayerManager] Skipping deactivated account "${data.username}"`);
         continue;
       }
 
@@ -460,6 +549,8 @@ export class PlayerManager {
       }
     }
 
+    console.log(`[Startup] Phase 1: ${validSaves.length} sessions deserialized in ${(performance.now() - phaseStart).toFixed(1)}ms`);
+
     // Phase 2: Group by saved partyId
     const partyGroups = new Map<string, PlayerSaveData[]>();
     const soloSaves: PlayerSaveData[] = [];
@@ -475,6 +566,7 @@ export class PlayerManager {
     }
 
     // Phase 3: Restore multi-player parties
+    phaseStart = performance.now();
     for (const [savedPartyId, group] of partyGroups) {
       // If only one member left, treat as solo
       if (group.length === 1) {
@@ -530,7 +622,10 @@ export class PlayerManager {
       console.log(`[PlayerManager] Restored party "${savedPartyId}" with ${members.length} members`);
     }
 
+    console.log(`[Startup] Phase 3: ${partyGroups.size} multi-player parties restored in ${(performance.now() - phaseStart).toFixed(1)}ms`);
+
     // Phase 4: Restore solo players (no party or single-member groups)
+    phaseStart = performance.now();
     for (const data of soloSaves) {
       const coord = offsetToCube(data.position);
       const currentTile = this.grid.getTile(coord);
@@ -554,6 +649,7 @@ export class PlayerManager {
     }
 
     if (saves.length > 0) {
+      console.log(`[Startup] Phase 4: ${soloSaves.length} solo parties created in ${(performance.now() - phaseStart).toFixed(1)}ms`);
       console.log(`[PlayerManager] Restored ${this.sessions.size} sessions`);
     }
   }

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -182,6 +182,11 @@ export class PlayerSession {
     return this.unlockSystem.isUnlocked(tile);
   }
 
+  /** Returns true if this player has never completed a battle (truly new player). */
+  isNewPlayer(): boolean {
+    return this.battleCount === 0;
+  }
+
   incrementBattleCount(): void {
     this.battleCount++;
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -214,8 +214,9 @@ wss.on('connection', (ws) => {
   console.log(`WebSocket connected for "${username}"`);
 
   // Register the connection and send initial state
-  playerManager.login(ws, username);
-  playerManager.sendStateToPlayer(username);
+  playerManager.login(ws, username).then(() => {
+    playerManager.sendStateToPlayer(username);
+  });
 
   ws.on('message', (data) => {
     try {
@@ -313,8 +314,10 @@ wss.on('connection', (ws) => {
           playerManager.partyBattles.restartBattle(classPartyId);
         }
         playerManager.sendStateToPlayer(username);
-        // Broadcast welcome message to all online players
-        playerManager.broadcastWelcome(username, msg.className as ClassName);
+        // Only broadcast welcome for truly new players (not returning from ban/reset)
+        if (session.isNewPlayer()) {
+          playerManager.broadcastWelcome(username, msg.className as ClassName);
+        }
         return;
       }
 
@@ -1073,14 +1076,23 @@ wss.on('connection', (ws) => {
 const PORT = process.env.PORT ?? 3001;
 
 async function start() {
+  const startupStart = performance.now();
+
+  const t0 = performance.now();
   await accountStore.load();
+  console.log(`[Startup] AccountStore loaded in ${(performance.now() - t0).toFixed(1)}ms`);
+
   tokenStore.start();
   sessionStore.startReap();
+
+  const t1 = performance.now();
   await gameLoop.init(accountStore);
+  console.log(`[Startup] GameLoop.init completed in ${(performance.now() - t1).toFixed(1)}ms`);
+
   playerManager = gameLoop.playerManager;
 
   server.listen(PORT, () => {
-    console.log(`Game server listening on port ${PORT}`);
+    console.log(`[Startup] Server listening on port ${PORT} — total startup ${(performance.now() - startupStart).toFixed(1)}ms`);
   });
 }
 

--- a/server/tests/BanSystem.test.ts
+++ b/server/tests/BanSystem.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PlayerManager } from '../src/game/PlayerManager.js';
+import { GuildStore } from '../src/game/social/GuildStore.js';
+import type { GameStateStore, PlayerSaveData } from '../src/game/GameStateStore.js';
+import type { AccountStore, Account } from '../src/auth/AccountStore.js';
+import { HexGrid, HexTile, offsetToCube } from '@idle-party-rpg/shared';
+import type { ContentStore } from '../src/game/ContentStore.js';
+
+// --- Minimal fakes ---
+
+function createFakeGrid(): HexGrid {
+  const grid = new HexGrid();
+  // Add a start tile and a second tile
+  const startCoord = offsetToCube({ col: 0, row: 0 });
+  grid.addTile(new HexTile(startCoord, 'town', 'hatchetmill', 'tile-start'));
+  const otherCoord = offsetToCube({ col: 1, row: 0 });
+  grid.addTile(new HexTile(otherCoord, 'forest', 'darkwood', 'tile-other'));
+  return grid;
+}
+
+function createFakeContentStore(): ContentStore {
+  return {
+    getStartTile: () => ({ col: 0, row: 0 }),
+    getMonster: () => ({ id: 'goblin', name: 'Goblin', hp: 10, damage: 2, drops: [], damageType: 'physical' }),
+    getItem: () => null,
+    getAllMonsters: () => ({}),
+    getAllItems: () => ({}),
+    getZone: () => ({
+      id: 'hatchetmill',
+      name: 'Hatchet Mill',
+      encounters: [{ monsterId: 'goblin', weight: 1, minCount: 1, maxCount: 1 }],
+    }),
+    getAllZones: () => ({}),
+  } as unknown as ContentStore;
+}
+
+function createFakeAccountStore(accounts: Record<string, Account>): AccountStore {
+  return {
+    findByUsername: (username: string) => {
+      for (const acct of Object.values(accounts)) {
+        if (acct.username === username) return acct;
+      }
+      return null;
+    },
+    getAllUsernames: () => Object.values(accounts).map(a => a.username).filter(Boolean) as string[],
+    updateLastActive: vi.fn().mockResolvedValue(undefined),
+    setDeactivated: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AccountStore;
+}
+
+function createFakeStore(): GameStateStore & { saved: PlayerSaveData[] } {
+  const saved: PlayerSaveData[] = [];
+  return {
+    saved,
+    save: vi.fn().mockResolvedValue(undefined),
+    saveAll: vi.fn(async (data: PlayerSaveData[]) => { saved.push(...data); }),
+    load: vi.fn().mockResolvedValue(null),
+    loadAll: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createFakeGuildStore(): GuildStore {
+  return new GuildStore();
+}
+
+// --- Tests ---
+
+describe('Ban System', () => {
+  let grid: HexGrid;
+  let content: ContentStore;
+  let guildStore: GuildStore;
+
+  beforeEach(() => {
+    grid = createFakeGrid();
+    content = createFakeContentStore();
+    guildStore = createFakeGuildStore();
+  });
+
+  describe('restoreFromSaveData', () => {
+    it('skips deactivated (banned) accounts during restore', () => {
+      const accounts: Record<string, Account> = {
+        'alice@test.com': {
+          email: 'alice@test.com',
+          username: 'alice',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+          deactivated: true,
+        },
+        'bob@test.com': {
+          email: 'bob@test.com',
+          username: 'bob',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        },
+      };
+
+      const accountStore = createFakeAccountStore(accounts);
+      const store = createFakeStore();
+      const pm = new PlayerManager(grid, content, guildStore, accountStore, store);
+
+      const saves: PlayerSaveData[] = [
+        {
+          username: 'alice',
+          battleCount: 50,
+          combatLog: [],
+          unlockedKeys: ['tile-start'],
+          position: { col: 0, row: 0 },
+          target: null,
+          movementQueue: [],
+          character: { className: 'Knight', level: 10, xp: 5000 },
+        },
+        {
+          username: 'bob',
+          battleCount: 30,
+          combatLog: [],
+          unlockedKeys: ['tile-start'],
+          position: { col: 0, row: 0 },
+          target: null,
+          movementQueue: [],
+          character: { className: 'Archer', level: 5, xp: 1000 },
+        },
+      ];
+
+      pm.restoreFromSaveData(saves);
+
+      // Bob should be restored, Alice should not
+      expect(pm.getSessionByUsername('bob')).toBeDefined();
+      expect(pm.getSessionByUsername('alice')).toBeUndefined();
+      expect(pm.sessionCount).toBe(1);
+    });
+
+    it('does not include deactivated accounts in otherPlayers', () => {
+      const accounts: Record<string, Account> = {
+        'alice@test.com': {
+          email: 'alice@test.com',
+          username: 'alice',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+          deactivated: true,
+        },
+        'bob@test.com': {
+          email: 'bob@test.com',
+          username: 'bob',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        },
+      };
+
+      const accountStore = createFakeAccountStore(accounts);
+      const store = createFakeStore();
+      const pm = new PlayerManager(grid, content, guildStore, accountStore, store);
+
+      const saves: PlayerSaveData[] = [
+        {
+          username: 'bob',
+          battleCount: 30,
+          combatLog: [],
+          unlockedKeys: ['tile-start'],
+          position: { col: 0, row: 0 },
+          target: null,
+          movementQueue: [],
+          character: { className: 'Archer', level: 5, xp: 1000 },
+        },
+      ];
+
+      pm.restoreFromSaveData(saves);
+
+      const others = pm.getOtherPlayers('bob');
+      expect(others).toHaveLength(0);
+      // Alice is banned so should not appear
+      expect(others.find(p => p.username === 'alice')).toBeUndefined();
+    });
+  });
+
+  describe('restoreFromSaveData after unban', () => {
+    it('restores an unbanned player normally — keeps position and party across server restarts', () => {
+      // Alice was previously banned but has since been reactivated
+      const accounts: Record<string, Account> = {
+        'alice@test.com': {
+          email: 'alice@test.com',
+          username: 'alice',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+          deactivated: false, // explicitly unbanned
+        },
+        'bob@test.com': {
+          email: 'bob@test.com',
+          username: 'bob',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        },
+      };
+
+      const accountStore = createFakeAccountStore(accounts);
+      const store = createFakeStore();
+      const pm = new PlayerManager(grid, content, guildStore, accountStore, store);
+
+      // Simulate save data from after Alice was unbanned and played —
+      // she's at a non-start position (col:1, row:0) in a party with Bob
+      const partyId = 'party-abc';
+      const saves: PlayerSaveData[] = [
+        {
+          username: 'alice',
+          battleCount: 60,
+          combatLog: [],
+          unlockedKeys: ['tile-start', 'tile-other'],
+          position: { col: 1, row: 0 },
+          target: null,
+          movementQueue: [],
+          character: { className: 'Knight', level: 12, xp: 8000 },
+          partyId,
+          partyRole: 'member',
+          partyGridPosition: 1,
+        },
+        {
+          username: 'bob',
+          battleCount: 40,
+          combatLog: [],
+          unlockedKeys: ['tile-start', 'tile-other'],
+          position: { col: 1, row: 0 },
+          target: null,
+          movementQueue: [],
+          character: { className: 'Archer', level: 8, xp: 3000 },
+          partyId,
+          partyRole: 'owner',
+          partyGridPosition: 4,
+        },
+      ];
+
+      pm.restoreFromSaveData(saves);
+
+      // Both should be restored
+      const aliceSession = pm.getSessionByUsername('alice');
+      const bobSession = pm.getSessionByUsername('bob');
+      expect(aliceSession).toBeDefined();
+      expect(bobSession).toBeDefined();
+      expect(pm.sessionCount).toBe(2);
+
+      // Alice should be at her saved position (col:1, row:0), NOT the start tile
+      const alicePos = aliceSession!.getPosition();
+      expect(alicePos.col).toBe(1);
+      expect(alicePos.row).toBe(0);
+
+      // Alice's character data should be preserved
+      expect(aliceSession!.getLevel()).toBe(12);
+      expect(aliceSession!.getClassName()).toBe('Knight');
+
+      // Both should be in the same party
+      expect(aliceSession!.getPartyId()).toBe(bobSession!.getPartyId());
+    });
+
+    it('does not reset an unbanned player on a second server restart', () => {
+      // Simulate: Alice was banned, unbanned, played, server restarted once
+      // (first restart restored her fine), then server restarts AGAIN.
+      // She should still be at her position, not reset to start.
+      const accounts: Record<string, Account> = {
+        'alice@test.com': {
+          email: 'alice@test.com',
+          username: 'alice',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+          deactivated: false,
+        },
+      };
+
+      const accountStore = createFakeAccountStore(accounts);
+      const store = createFakeStore();
+
+      // First restart — restore Alice at non-start position
+      const pm1 = new PlayerManager(grid, content, guildStore, accountStore, store);
+      pm1.restoreFromSaveData([{
+        username: 'alice',
+        battleCount: 70,
+        combatLog: [],
+        unlockedKeys: ['tile-start', 'tile-other'],
+        position: { col: 1, row: 0 },
+        target: null,
+        movementQueue: [],
+        character: { className: 'Knight', level: 15, xp: 20000 },
+      }]);
+
+      const session1 = pm1.getSessionByUsername('alice')!;
+      expect(session1.getPosition()).toEqual({ col: 1, row: 0 });
+      expect(session1.getLevel()).toBe(15);
+
+      // Collect save data as if the server is shutting down
+      const saveData = pm1.getAllSaveData();
+      expect(saveData).toHaveLength(1);
+      expect(saveData[0].position).toEqual({ col: 1, row: 0 });
+
+      // Second restart — restore from the save data produced above
+      const pm2 = new PlayerManager(grid, content, guildStore, accountStore, store);
+      pm2.restoreFromSaveData(saveData);
+
+      const session2 = pm2.getSessionByUsername('alice')!;
+      expect(session2).toBeDefined();
+      // Position should still be (1,0), NOT reset to start (0,0)
+      expect(session2.getPosition()).toEqual({ col: 1, row: 0 });
+      expect(session2.getLevel()).toBe(15);
+      expect(session2.getClassName()).toBe('Knight');
+    });
+  });
+
+  describe('banPlayer', () => {
+    it('removes session and saves state on ban', async () => {
+      const accounts: Record<string, Account> = {
+        'alice@test.com': {
+          email: 'alice@test.com',
+          username: 'alice',
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        },
+      };
+
+      const accountStore = createFakeAccountStore(accounts);
+      const store = createFakeStore();
+      const pm = new PlayerManager(grid, content, guildStore, accountStore, store);
+
+      // Restore alice's session
+      pm.restoreFromSaveData([{
+        username: 'alice',
+        battleCount: 50,
+        combatLog: [],
+        unlockedKeys: ['tile-start'],
+        position: { col: 0, row: 0 },
+        target: null,
+        movementQueue: [],
+        character: { className: 'Knight', level: 10, xp: 5000 },
+      }]);
+
+      expect(pm.getSessionByUsername('alice')).toBeDefined();
+      expect(pm.sessionCount).toBe(1);
+
+      // Ban alice
+      await pm.banPlayer('alice');
+
+      // Session should be removed
+      expect(pm.getSessionByUsername('alice')).toBeUndefined();
+      expect(pm.sessionCount).toBe(0);
+
+      // State should have been saved
+      expect(store.saved.length).toBe(1);
+      expect(store.saved[0].username).toBe('alice');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Ban enforcement**: `banPlayer()` now fully removes players from party, combat, map, and in-memory session. Banned players are skipped during server restart restore, preventing XP gain while banned.
- **Unban flow**: Unbanned players return at the starting room with a fresh solo party, preserving their character/inventory/level. Successive server restarts do not re-reset them.
- **Welcome announcement**: Only fires for truly new players (`battleCount === 0`), not players returning from a ban or class reset.
- **Admin UI**: Banned and no-character accounts hidden by default with "Show banned" / "Show no character" toggle filters. Reactivation requests show a 💬 icon next to the BAN badge.
- **Startup timing**: `[Startup]` logs with per-step `performance.now()` timing across all init phases (content load, grid build, save file I/O, session restore phases).
- **Tests**: 5 new BanSystem tests covering restore skipping, ban cleanup, party preservation after unban, and successive restart stability.

## Test plan
- [x] All 90 tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [ ] Manual: ban a player via admin, verify they vanish from map/party/combat
- [ ] Manual: unban player, verify they return at start room with character intact
- [ ] Manual: verify admin accounts tab hides banned/no-char by default
- [ ] Manual: check startup logs show `[Startup]` timing for each phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)