### PR TITLE
Chat & combat log QoL improvements

### DIFF
--- a/client/src/network/GameClient.ts
+++ b/client/src/network/GameClient.ts
@@ -370,8 +370,8 @@ export class GameClient {
     this.sendRaw({ type: 'request_chat_history', channelType, channelId });
   }
 
-  sendSetChatPreferences(sendChannel: string, dmTarget: string): void {
-    this.sendRaw({ type: 'set_chat_preferences', sendChannel, dmTarget });
+  sendSetChatPreferences(sendChannel: string, dmTarget: string, filters?: string[]): void {
+    this.sendRaw({ type: 'set_chat_preferences', sendChannel, dmTarget, filters });
   }
 
   /** Subscribe to incoming chat messages. Returns an unsubscribe function. */

--- a/client/src/screens/CombatScreen.ts
+++ b/client/src/screens/CombatScreen.ts
@@ -15,12 +15,19 @@ export class CombatScreen implements Screen {
   private playerSide!: HTMLElement;
   private enemySide!: HTMLElement;
   private logContainer!: HTMLElement;
+  private logWrapper!: HTMLElement;
+  private resumeBtn!: HTMLElement;
+  private fullscreenBtn!: HTMLElement;
 
   // Last rendered log entry ID — for incremental DOM updates
   private lastRenderedId = -1;
   private lastLog: CombatLogEntry[] = [];
   private renderedPlayerKey = '';
   private renderedEnemyKey = '';
+
+  // Pause/fullscreen state
+  private paused = false;
+  private isFullscreen = false;
 
   constructor(containerId: string, gameClient: GameClient) {
     const el = document.getElementById(containerId);
@@ -64,7 +71,13 @@ export class CombatScreen implements Screen {
         <div class="combat-vs">\u2694</div>
         <div class="combat-side combat-enemy-side"></div>
       </div>
-      <div class="combat-log"></div>
+      <div class="combat-log-wrapper">
+        <div class="combat-log-controls">
+          <button class="log-fullscreen-btn" title="Fullscreen">\u26F6</button>
+        </div>
+        <div class="combat-log"></div>
+        <button class="log-resume-btn" style="display:none">\u25BC Resume Live</button>
+      </div>
     `;
 
     this.locationLabel = this.container.querySelector('.location-label')!;
@@ -72,7 +85,33 @@ export class CombatScreen implements Screen {
     this.stage = this.container.querySelector('.combat-stage')!;
     this.playerSide = this.container.querySelector('.combat-player-side')!;
     this.enemySide = this.container.querySelector('.combat-enemy-side')!;
+    this.logWrapper = this.container.querySelector('.combat-log-wrapper')!;
     this.logContainer = this.container.querySelector('.combat-log')!;
+    this.resumeBtn = this.container.querySelector('.log-resume-btn')!;
+    this.fullscreenBtn = this.container.querySelector('.log-fullscreen-btn')!;
+
+    // Auto-pause on user scroll
+    this.logContainer.addEventListener('scroll', () => {
+      if (this.paused) return;
+      const { scrollTop, scrollHeight, clientHeight } = this.logContainer;
+      if (scrollTop + clientHeight < scrollHeight - 20) {
+        this.setPaused(true);
+      }
+    });
+
+    // Resume button
+    this.resumeBtn.addEventListener('click', () => {
+      this.setPaused(false);
+      this.renderLog(this.lastLog);
+    });
+
+    // Fullscreen toggle
+    this.fullscreenBtn.addEventListener('click', () => {
+      this.isFullscreen = !this.isFullscreen;
+      this.logWrapper.classList.toggle('fullscreen', this.isFullscreen);
+      this.fullscreenBtn.textContent = this.isFullscreen ? '\u2716' : '\u26F6';
+      this.fullscreenBtn.title = this.isFullscreen ? 'Exit Fullscreen' : 'Fullscreen';
+    });
   }
 
   private wireSubscriptions(): void {
@@ -269,7 +308,15 @@ export class CombatScreen implements Screen {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
+  private setPaused(paused: boolean): void {
+    this.paused = paused;
+    this.resumeBtn.style.display = paused ? '' : 'none';
+  }
+
   private updateLog(log: CombatLogEntry[]): void {
+    // When paused, don't update DOM — just track latest data
+    if (this.paused) return;
+
     const lastId = log.length > 0 ? log[log.length - 1].id : -1;
 
     // Nothing new — skip
@@ -310,8 +357,15 @@ export class CombatScreen implements Screen {
   private appendLogEntry(entry: CombatLogEntry): void {
     const div = document.createElement('div');
     div.className = `log-entry ${entry.type}`;
-    div.textContent = entry.text;
+    div.innerHTML = CombatScreen.formatLogText(this.escapeHtml(entry.text));
     this.logContainer.appendChild(div);
     this.logContainer.scrollTop = this.logContainer.scrollHeight;
+  }
+
+  private static formatLogText(escaped: string): string {
+    return escaped.replace(
+      /\b(physical|magical|holy)\b/gi,
+      (match) => `<span class="dmg-${match.toLowerCase()}">${match}</span>`,
+    );
   }
 }

--- a/client/src/screens/SettingsScreen.ts
+++ b/client/src/screens/SettingsScreen.ts
@@ -2,6 +2,16 @@ import type { Screen } from './ScreenManager';
 
 const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.03.28.1',
+    notes: [
+      'Chat filter choices now persist across sessions — your toggled channels are saved to your account',
+      'Combat log increased from 100 to 1000 entries',
+      'Combat log can now be paused by scrolling up — a "Resume Live" button appears to jump back to live updates',
+      'Added fullscreen toggle for the combat log',
+      'Damage types (physical, magical, holy) are now shown and color-coded in the combat log',
+    ],
+  },
+  {
     version: '2026.03.26.1',
     notes: [
       'Added View Player — click any username to see their level, class, guild, equipped items, skills, and party members',

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -117,6 +117,9 @@ export class SocialScreen implements Screen {
       if (!this.chatPrefsInitialized && state.social?.chatPreferences) {
         this.chatSendChannel = state.social.chatPreferences.sendChannel;
         this.chatDmTarget = state.social.chatPreferences.dmTarget;
+        if (state.social.chatPreferences.filters) {
+          this.chatFilters = new Set(state.social.chatPreferences.filters);
+        }
         this.chatPrefsInitialized = true;
       }
       this.renderTabBar();
@@ -265,6 +268,7 @@ export class SocialScreen implements Screen {
         }
         btn.classList.toggle('active');
         this.renderChatMessages();
+        this.gameClient.sendSetChatPreferences(this.chatSendChannel, this.chatDmTarget, Array.from(this.chatFilters));
         return;
       }
 
@@ -444,6 +448,9 @@ export class SocialScreen implements Screen {
     if (!this.chatPrefsInitialized && state.social?.chatPreferences) {
       this.chatSendChannel = state.social.chatPreferences.sendChannel;
       this.chatDmTarget = state.social.chatPreferences.dmTarget;
+      if (state.social.chatPreferences.filters) {
+        this.chatFilters = new Set(state.social.chatPreferences.filters);
+      }
       this.chatPrefsInitialized = true;
     }
 

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -398,12 +398,9 @@ html, body {
 /* Combat log */
 .combat-log {
   flex: 1;
-  min-height: 80px;
-  max-height: 200px;
   overflow-y: auto;
   padding: 8px 12px;
   background: var(--bg-input);
-  border-top: 2px solid var(--border-pixel);
   font-size: 8px;
   line-height: 1.8;
   color: var(--text-secondary);
@@ -452,6 +449,76 @@ html, body {
 .log-entry.levelup {
   color: var(--accent-gold);
   font-weight: bold;
+}
+
+/* Damage type color coding */
+.dmg-physical { color: var(--accent-orange); font-weight: bold; }
+.dmg-magical { color: #b388ff; font-weight: bold; }
+.dmg-holy { color: var(--accent-gold); font-weight: bold; }
+
+/* ── Combat Log Wrapper & Controls ─────────────────────── */
+
+.combat-log-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 80px;
+  max-height: 200px;
+}
+
+.combat-log-wrapper.fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: none;
+  z-index: 1000;
+  background: var(--bg-surface);
+}
+
+.combat-log-controls {
+  display: flex;
+  justify-content: flex-end;
+  padding: 2px 4px;
+  background: var(--bg-input);
+  border-top: 2px solid var(--border-pixel);
+}
+
+.log-fullscreen-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 4px;
+  font-family: inherit;
+}
+
+.log-fullscreen-btn:hover {
+  color: var(--text-primary);
+}
+
+.log-resume-btn {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-surface);
+  border: 2px solid var(--border-pixel);
+  color: var(--accent-green);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  padding: 4px 12px;
+  cursor: pointer;
+  z-index: 10;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+}
+
+.log-resume-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-input);
 }
 
 /* ── Settings Screen ────────────────────────────────────── */
@@ -2999,6 +3066,7 @@ html, body {
   .combat-hp-label { font-size: 9px; }
   .log-entry { font-size: 10px; }
   .combat-log { font-size: 10px; }
+  .log-resume-btn { font-size: 10px; }
   .character-class-name { font-size: 12px; }
   .character-level { font-size: 11px; }
   .character-xp-label { font-size: 9px; }

--- a/server/src/game/GameStateStore.ts
+++ b/server/src/game/GameStateStore.ts
@@ -34,6 +34,7 @@ export interface PlayerSaveData {
   chatHistory?: ChatMessage[];
   chatSendChannel?: string;
   chatDmTarget?: string;
+  chatFilters?: string[];
 }
 
 /**

--- a/server/src/game/PlayerManager.ts
+++ b/server/src/game/PlayerManager.ts
@@ -344,6 +344,7 @@ export class PlayerManager {
       chatPreferences: {
         sendChannel: session?.getChatSendChannel() ?? 'zone',
         dmTarget: session?.getChatDmTarget() ?? '',
+        filters: session?.getChatFilters(),
       },
       pendingTrade: this.trades.getPlayerTrade(username),
     };

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -52,7 +52,7 @@ import type {
 import type { PlayerSaveData } from './GameStateStore.js';
 import type { ContentStore } from './ContentStore.js';
 
-const MAX_LOG_ENTRIES = 100;
+const MAX_LOG_ENTRIES = 1000;
 const MAX_SAVE_LOG_ENTRIES = 1000;
 const MAX_CHAT_HISTORY = 1000;
 
@@ -73,6 +73,7 @@ export class PlayerSession {
   private partyId: string | null = null;
   private chatSendChannel: ChatChannelType = 'zone';
   private chatDmTarget = '';
+  private chatFilters: ChatChannelType[] = ['tile', 'zone', 'party', 'guild', 'global', 'dm', 'server'];
 
   /** XP rate tracking — in-memory only, resets on server restart. */
   private xpRateStartTime = Date.now();
@@ -307,6 +308,8 @@ export class PlayerSession {
   setChatSendChannel(channel: ChatChannelType): void { this.chatSendChannel = channel; }
   getChatDmTarget(): string { return this.chatDmTarget; }
   setChatDmTarget(target: string): void { this.chatDmTarget = target; }
+  getChatFilters(): ChatChannelType[] { return this.chatFilters; }
+  setChatFilters(filters: ChatChannelType[]): void { this.chatFilters = filters; }
 
   /** Store a chat message in this player's personal history. */
   addChatMessage(message: ChatMessage): void {
@@ -519,6 +522,7 @@ export class PlayerSession {
       chatHistory: this.chatHistory.slice(-MAX_CHAT_HISTORY),
       chatSendChannel: this.chatSendChannel,
       chatDmTarget: this.chatDmTarget,
+      chatFilters: [...this.chatFilters],
     };
   }
 
@@ -602,6 +606,9 @@ export class PlayerSession {
     session['chatHistory'] = data.chatHistory ? [...data.chatHistory] : [];
     session['chatSendChannel'] = (data.chatSendChannel as ChatChannelType) ?? 'zone';
     session['chatDmTarget'] = data.chatDmTarget ?? '';
+    session['chatFilters'] = data.chatFilters
+      ? data.chatFilters as ChatChannelType[]
+      : ['tile', 'zone', 'party', 'guild', 'global', 'dm', 'server'];
 
     // XP rate tracking — auto-start from session restore time
     session['xpRateStartTime'] = Date.now();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -533,6 +533,9 @@ wss.on('connection', (ws) => {
         if (session) {
           session.setChatSendChannel(msg.sendChannel);
           session.setChatDmTarget(msg.dmTarget ?? '');
+          if (Array.isArray(msg.filters)) {
+            session.setChatFilters(msg.filters);
+          }
         }
         return;
       }

--- a/shared/src/systems/CombatEngine.ts
+++ b/shared/src/systems/CombatEngine.ts
@@ -307,7 +307,7 @@ function executeActiveSkill(
 
       const damage = computePlayerDamage(player, state.rallyMultiplier);
       target.currentHp = Math.max(0, target.currentHp - damage);
-      logEntries.push(`${player.username} uses ${skill.name} on ${target.name} for ${damage} damage`);
+      logEntries.push(`${player.username} uses ${skill.name} on ${target.name} for ${damage} ${player.playerDamageType} damage`);
 
       let stunApplied = false;
       if (target.currentHp > 0 && Math.random() < (effect.stunChance ?? 0)) {
@@ -383,7 +383,7 @@ function executeActiveSkill(
         if (!target) break;
         lastTarget = target;
         target.currentHp = Math.max(0, target.currentHp - perHitDamage);
-        logEntries.push(`${player.username}'s ${skill.name} hits ${target.name} for ${perHitDamage} damage`);
+        logEntries.push(`${player.username}'s ${skill.name} hits ${target.name} for ${perHitDamage} ${player.playerDamageType} damage`);
         if (target.currentHp <= 0) {
           logEntries.push(`${target.name} defeated!`);
         }
@@ -407,7 +407,7 @@ function executeActiveSkill(
 
       const damage = computePlayerDamage(player, state.rallyMultiplier);
       target.currentHp = Math.max(0, target.currentHp - damage);
-      logEntries.push(`${player.username} uses ${skill.name} on ${target.name} for ${damage} damage`);
+      logEntries.push(`${player.username} uses ${skill.name} on ${target.name} for ${damage} ${player.playerDamageType} damage`);
 
       if (target.currentHp <= 0) {
         logEntries.push(`${target.name} defeated!`);
@@ -503,7 +503,7 @@ export function processPartyTick(state: PartyCombatState): TickResult {
         if (target) {
           const damage = computePlayerDamage(player, state.rallyMultiplier);
           target.currentHp = Math.max(0, target.currentHp - damage);
-          logEntries.push(`${player.username} hits ${target.name} for ${damage} damage`);
+          logEntries.push(`${player.username} hits ${target.name} for ${damage} ${player.playerDamageType} damage`);
 
           if (target.currentHp <= 0) {
             logEntries.push(`${target.name} defeated!`);
@@ -572,7 +572,7 @@ export function processPartyTick(state: PartyCombatState): TickResult {
 
           const damage = Math.max(0, monster.damage - reduction);
           target.currentHp = Math.max(0, target.currentHp - damage);
-          logEntries.push(`${monster.name} hits ${target.username} for ${damage} damage`);
+          logEntries.push(`${monster.name} hits ${target.username} for ${damage} ${monster.damageType} damage`);
         }
 
         state.lastAction = {

--- a/shared/src/systems/SocialTypes.ts
+++ b/shared/src/systems/SocialTypes.ts
@@ -114,6 +114,7 @@ export interface ClientSocialState {
 export interface ChatPreferences {
   sendChannel: ChatChannelType;
   dmTarget: string;
+  filters?: ChatChannelType[];
 }
 
 // --- Client -> Server messages ---


### PR DESCRIPTION
## Summary
- **Persistent chat filters**: Chat filter toggles (Room/Zone/Party/Guild/World/DM/Server) now save to the player's account and restore on login — no more losing your filter choices on refresh
- **Combat log upgrades**: Increased from 100 to 1000 entries, auto-pauses on scroll-up with a "Resume Live" button, and added a fullscreen toggle
- **Damage type indicators**: All combat log entries now show damage type (physical/magical/holy) with color-coded text (orange/purple/gold)

## Test plan
- [x] `npm run build` passes
- [x] All 278 tests pass (`npm run test`)
- [ ] Toggle chat filters, refresh page — filters should persist
- [ ] Scroll up in combat log — should auto-pause with "Resume Live" button
- [ ] Click "Resume Live" — should jump back to live updates
- [ ] Click fullscreen button on combat log — should expand to fill screen
- [ ] Verify damage type text appears in combat log entries (e.g., "hits Goblin for 12 physical damage")
- [ ] Verify damage type words are color-coded (physical=orange, magical=purple, holy=gold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)