### PR TITLE
Fix Run button visibility and fullscreen resume button

### DIFF
--- a/client/src/screens/CombatScreen.ts
+++ b/client/src/screens/CombatScreen.ts
@@ -367,12 +367,21 @@ export class CombatScreen implements Screen {
     const myRole = state.social?.party?.members.find(m => m.username === state.username)?.role;
     const canRun = myRole === 'owner' || myRole === 'leader';
 
-    if (!isFighting || !canRun || this.isFullscreen) {
+    if (!isFighting || this.isFullscreen) {
       this.runBar.style.display = 'none';
       return;
     }
 
     this.runBar.style.display = '';
+
+    if (!canRun) {
+      this.runBtn.disabled = true;
+      this.runBtn.textContent = '\uD83D\uDD12 Run';
+      this.runBtn.title = 'Only the party owner or a leader can run';
+      return;
+    }
+
+    this.runBtn.title = '';
     const available = roundCount >= RUN_AVAILABLE_ROUNDS;
     this.runBtn.disabled = !available;
     this.runBtn.textContent = available ? 'Run' : '\uD83D\uDD12 Run';

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -483,7 +483,7 @@ html, body {
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
+  bottom: var(--nav-height);
   max-height: none;
   z-index: 1000;
   background: var(--bg-surface);


### PR DESCRIPTION
## Summary
- **Run button visible for all players**: Previously hidden entirely for non-owner/non-leader party members. Now always shown during combat — disabled with a tooltip ("Only the party owner or a leader can run") for non-leaders.
- **Resume Live button in fullscreen**: The fullscreen log wrapper extended to `bottom: 0`, placing the resume button behind the 56px bottom nav. Changed to `bottom: var(--nav-height)` so the fullscreen log stops above the nav bar.

## Test plan
- [ ] Join a party as a non-leader member, verify the Run button is visible (disabled with tooltip)
- [ ] As party owner/leader, verify Run button enables after 5 rounds
- [ ] Fullscreen the combat log, scroll up, verify Resume Live button is visible above the nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)