### PR TITLE
Show hint on click for disabled Run button

### DIFF
--- a/client/src/screens/CombatScreen.ts
+++ b/client/src/screens/CombatScreen.ts
@@ -377,14 +377,14 @@ export class CombatScreen implements Screen {
     if (!canRun) {
       this.runBtn.disabled = true;
       this.runBtn.textContent = '\uD83D\uDD12 Run';
-      this.runBtn.title = 'Only the party owner or a leader can run';
+      this.runHint.textContent = 'Only the party owner or a leader can run';
       return;
     }
 
-    this.runBtn.title = '';
     const available = roundCount >= RUN_AVAILABLE_ROUNDS;
     this.runBtn.disabled = !available;
     this.runBtn.textContent = available ? 'Run' : '\uD83D\uDD12 Run';
+    this.runHint.textContent = `Available after ${RUN_AVAILABLE_ROUNDS} combat rounds`;
   }
 
   private showRunHint(): void {


### PR DESCRIPTION
## Summary
- Replace `title` tooltip (doesn't work on mobile) with the existing click-to-show hint mechanism
- Hint text updates dynamically: "Only the party owner or a leader can run" for non-leaders, "Available after 5 combat rounds" for locked rounds

## Test plan
- [ ] As a non-leader party member, click the disabled Run button — verify hint text appears
- [ ] As owner/leader before round 5, click the locked Run button — verify round hint appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)