### PR TITLE
Auto-reload clients on server deploy

### DIFF
--- a/client/src/network/GameClient.ts
+++ b/client/src/network/GameClient.ts
@@ -38,6 +38,9 @@ export class GameClient {
   /** Most recent state from the server (null until first message). */
   lastState: ServerStateMessage | null = null;
 
+  /** Server version from first state message — reload if it changes. */
+  private knownServerVersion: string | null = null;
+
   constructor() {
     const host = window.location.hostname || 'localhost';
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -126,6 +129,15 @@ export class GameClient {
         const msg = JSON.parse(event.data as string);
 
         if (msg.type === 'state') {
+          if (msg.serverVersion) {
+            if (this.knownServerVersion === null) {
+              this.knownServerVersion = msg.serverVersion;
+            } else if (msg.serverVersion !== this.knownServerVersion) {
+              console.log('[GameClient] Server version changed, reloading...');
+              location.reload();
+              return;
+            }
+          }
           this.lastState = msg;
 
           // Resolve pending connect on first state message

--- a/server/src/game/PlayerManager.ts
+++ b/server/src/game/PlayerManager.ts
@@ -28,6 +28,7 @@ export class PlayerManager {
   readonly trades: TradeSystem;
   readonly partyBattles: PartyBattleManager;
   private getAllUsernames: () => string[];
+  private readonly serverVersion = Date.now().toString();
 
   constructor(grid: HexGrid, content: ContentStore, guildStore: GuildStore, accountStore: AccountStore, store: GameStateStore) {
     this.grid = grid;
@@ -293,7 +294,7 @@ export class PlayerManager {
     if (!session) return;
 
     const otherPlayers = this.getOtherPlayers(username);
-    const state = JSON.stringify({ type: 'state' as const, ...session.getState(otherPlayers) });
+    const state = JSON.stringify({ type: 'state' as const, ...session.getState(otherPlayers), serverVersion: this.serverVersion });
 
     for (const ws of wsSet) {
       if (ws.readyState === WebSocket.OPEN) {

--- a/server/src/game/PlayerSession.ts
+++ b/server/src/game/PlayerSession.ts
@@ -253,7 +253,7 @@ export class PlayerSession {
     return defs;
   }
 
-  getState(otherPlayers: OtherPlayerState[]): Omit<ServerStateMessage, 'type'> {
+  getState(otherPlayers: OtherPlayerState[]): Omit<ServerStateMessage, 'type' | 'serverVersion'> {
     const battleState = this.getBattleState?.();
     const partyState = this.getPartyPositionState?.();
     const partyZone = this.getPartyZone?.();

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -140,6 +140,8 @@ export interface ServerStateMessage {
   social?: ClientSocialState;
   /** Item definitions for items the player currently owns (inventory + equipment). */
   itemDefinitions: Record<string, ItemDefinition>;
+  /** Server version identifier — changes on restart/deploy, triggers client reload on mismatch. */
+  serverVersion: string;
 }
 
 export interface ClientMoveMessage {


### PR DESCRIPTION
## Summary
- Server generates a version identifier (`Date.now()`) once at startup and includes it as `serverVersion` in every WebSocket state message
- Client stores the version from its first state message; if a subsequent message has a different version, it calls `location.reload()`
- Background tabs are handled naturally — the existing `visibilitychange` handler requests fresh state on tab return, triggering the reload

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run test` passes (90/90)
- [ ] Manual: start server, connect client, restart server → client reloads automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)