### PR TITLE
Fix session cookies expiring after 30 days

### DIFF
--- a/server/src/auth/JsonSessionStore.ts
+++ b/server/src/auth/JsonSessionStore.ts
@@ -44,11 +44,14 @@ export class JsonSessionStore extends session.Store {
       .catch((err) => callback?.(err));
   }
 
-  touch(sid: string, sessionData: session.SessionData, callback?: () => void): void {
+  touch(sid: string, sessionData: session.SessionData, callback?: (err?: any) => void): void {
     // Update the session file with the new cookie expiry
     this.writeSession(sid, sessionData)
       .then(() => callback?.())
-      .catch(() => callback?.());
+      .catch((err) => {
+        console.error(`[JsonSessionStore] Failed to touch session "${sid}":`, err);
+        callback?.(err);
+      });
   }
 
   // --- Reap (expired session cleanup) ---

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,6 +48,7 @@ const sessionMiddleware = session({
   store: sessionStore,
   secret: process.env.SESSION_SECRET ?? 'dev-secret',
   resave: false,
+  rolling: true,
   saveUninitialized: false,
   cookie: {
     httpOnly: true,


### PR DESCRIPTION
## Summary
- Enable `rolling: true` on express-session so the cookie `maxAge` resets on every response, preventing sign-outs for active users
- Fix silent error swallowing in `JsonSessionStore.touch()` — errors are now logged and passed through like `set()` and `destroy()`

**Root cause:** Without `rolling: true`, the session cookie expiry was fixed at creation time (30 days). The server-side session store kept refreshing its own expiry via `touch()`, but the browser's cookie was never updated. Sessions created at launch (~March 1) started expiring around April 1.

Closes #113

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (100 tests)
- [ ] After deploy, verify in browser devtools (Application → Cookies → `connect.sid`) that `Expires` updates on each page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)