### PR TITLE
Fix new users unable to see game without page refresh

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -246,8 +246,12 @@ export class App {
     }
 
     // Load world data now that the player session exists server-side
-    await this.worldCache.loadWorld().catch(err => {
-      console.warn('[App] Failed to load world data:', err);
+    await this.worldCache.loadWorld().catch(async () => {
+      // Retry once after a brief delay (session may not be fully persisted yet)
+      await new Promise(r => setTimeout(r, 500));
+      await this.worldCache.loadWorld().catch(err => {
+        console.warn('[App] Failed to load world data after retry:', err);
+      });
     });
 
     // Check if player needs to select a class (new player or reset Adventurer)

--- a/client/src/network/GameClient.ts
+++ b/client/src/network/GameClient.ts
@@ -127,60 +127,90 @@ export class GameClient {
     };
 
     this.ws.onmessage = (event) => {
+      let msg: any;
       try {
-        const msg = JSON.parse(event.data as string);
-
-        if (msg.type === 'state') {
-          if (msg.serverVersion) {
-            if (this.knownServerVersion === null) {
-              this.knownServerVersion = msg.serverVersion;
-            } else if (msg.serverVersion !== this.knownServerVersion) {
-              console.log('[GameClient] Server version changed, reloading...');
-              location.reload();
-              return;
-            }
-          }
-          this.lastState = msg;
-
-          // Resolve pending connect on first state message
-          if (this.connectResolve) {
-            this.connectResolve({ success: true });
-            this.connectResolve = undefined;
-          }
-
-          for (const listener of this.stateListeners) {
-            listener(msg);
-          }
-          this.isInitialState = false;
-        } else if (msg.type === 'chat_message') {
-          for (const listener of this.chatListeners) {
-            listener(msg.message);
-          }
-        } else if (msg.type === 'sync_chat') {
-          for (const listener of this.syncChatListeners) {
-            listener(msg.messages, msg.full);
-          }
-        } else if (msg.type === 'world_update') {
-          for (const listener of this.worldUpdateListeners) {
-            listener();
-          }
-        } else if (msg.type === 'equip_blocked') {
-          for (const listener of this.equipBlockedListeners) {
-            listener(msg);
-          }
-        } else if (msg.type === 'move_blocked') {
-          for (const listener of this.moveBlockedListeners) {
-            listener(msg);
-          }
-        } else if (msg.type === 'player_profile') {
-          for (const listener of this.playerProfileListeners) {
-            listener(msg);
-          }
-        } else if (msg.type === 'error') {
-          console.warn('[GameClient] server error:', msg.message);
-        }
+        msg = JSON.parse(event.data as string);
       } catch {
         console.error('[GameClient] failed to parse message');
+        return;
+      }
+
+      if (msg.type === 'state') {
+        if (msg.serverVersion) {
+          if (this.knownServerVersion === null) {
+            this.knownServerVersion = msg.serverVersion;
+          } else if (msg.serverVersion !== this.knownServerVersion) {
+            console.log('[GameClient] Server version changed, reloading...');
+            location.reload();
+            return;
+          }
+        }
+        this.lastState = msg;
+
+        // Resolve pending connect on first state message
+        if (this.connectResolve) {
+          this.connectResolve({ success: true });
+          this.connectResolve = undefined;
+        }
+
+        for (const listener of this.stateListeners) {
+          try {
+            listener(msg);
+          } catch (err) {
+            console.error('[GameClient] error in state listener:', err);
+          }
+        }
+        this.isInitialState = false;
+      } else if (msg.type === 'chat_message') {
+        for (const listener of this.chatListeners) {
+          try {
+            listener(msg.message);
+          } catch (err) {
+            console.error('[GameClient] error in chat listener:', err);
+          }
+        }
+      } else if (msg.type === 'sync_chat') {
+        for (const listener of this.syncChatListeners) {
+          try {
+            listener(msg.messages, msg.full);
+          } catch (err) {
+            console.error('[GameClient] error in sync_chat listener:', err);
+          }
+        }
+      } else if (msg.type === 'world_update') {
+        for (const listener of this.worldUpdateListeners) {
+          try {
+            listener();
+          } catch (err) {
+            console.error('[GameClient] error in world_update listener:', err);
+          }
+        }
+      } else if (msg.type === 'equip_blocked') {
+        for (const listener of this.equipBlockedListeners) {
+          try {
+            listener(msg);
+          } catch (err) {
+            console.error('[GameClient] error in equip_blocked listener:', err);
+          }
+        }
+      } else if (msg.type === 'move_blocked') {
+        for (const listener of this.moveBlockedListeners) {
+          try {
+            listener(msg);
+          } catch (err) {
+            console.error('[GameClient] error in move_blocked listener:', err);
+          }
+        }
+      } else if (msg.type === 'player_profile') {
+        for (const listener of this.playerProfileListeners) {
+          try {
+            listener(msg);
+          } catch (err) {
+            console.error('[GameClient] error in player_profile listener:', err);
+          }
+        }
+      } else if (msg.type === 'error') {
+        console.warn('[GameClient] server error:', msg.message);
       }
     };
 

--- a/client/src/screens/ClassSelectScreen.ts
+++ b/client/src/screens/ClassSelectScreen.ts
@@ -95,7 +95,9 @@ export class ClassSelectScreen implements Screen {
       const unsub = this.gameClient.subscribe((state) => {
         if (state.character.className !== 'Adventurer') {
           unsub();
-          this.onClassChosen();
+          // Defer to next microtask so enterGame() runs outside the subscriber
+          // loop — errors propagate properly instead of being swallowed
+          queueMicrotask(() => this.onClassChosen());
         }
       });
     });

--- a/client/src/screens/MapScreen.ts
+++ b/client/src/screens/MapScreen.ts
@@ -115,6 +115,13 @@ export class MapScreen implements Screen {
   }
 
   private async createPhaserGame(): Promise<void> {
+    // Ensure world data is loaded before creating the scene
+    if (!this.worldCache.isLoaded) {
+      await this.worldCache.loadWorld().catch(err => {
+        console.warn('[MapScreen] Failed to load world data:', err);
+      });
+    }
+
     const Phaser = await import('phaser');
     const { WorldMapScene } = await import('../scenes/WorldMapScene');
 


### PR DESCRIPTION
## Summary
- **GameClient**: Stop swallowing listener errors — the `onmessage` handler had a single try-catch around JSON parsing AND listener execution, so any error thrown by `enterGame()` during class selection was silently logged as "failed to parse message." Now each listener gets its own try-catch with proper error reporting.
- **ClassSelectScreen**: Defer `enterGame()` via `queueMicrotask()` so it runs outside the subscriber loop, avoiding timing issues with new subscribers being called mid-iteration.
- **World data resilience**: Retry `loadWorld()` once on failure (App.ts), and lazy-load world data in MapScreen if the cache is empty when the map tab is first opened.

Closes #79

## Test plan
- [ ] Create a new account in dev mode (login → username → class select)
- [ ] Verify game starts immediately after class selection (no refresh needed)
- [ ] Verify combat screen renders with battle data
- [ ] Verify map tab shows tiles on first visit
- [ ] Verify existing users (refresh/reconnect) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)