### PR TITLE
Add landing page for idlepartyrpg.com

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,1016 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Idle Party RPG — Your Party Fights 24/7</title>
+  <meta name="description" content="A multiplayer idle RPG where your party never stops. Your heroes fight, explore, and level up around the clock — even while you sleep." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+  <style>
+    /* ── Reset & Base ──────────────────────────────────── */
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --pixel-font: 'Press Start 2P', monospace;
+      --bg-dark: #1a1a2e;
+      --bg-panel: #16213e;
+      --bg-panel-light: #0f3460;
+      --bg-surface: #1a1a2e;
+      --border-pixel: #533483;
+      --border-light: #7b5ea7;
+      --text-primary: #e8e8e8;
+      --text-secondary: #a0a0b0;
+      --text-dim: #606070;
+      --accent-gold: #f5c842;
+      --accent-red: #ff6b6b;
+      --accent-green: #44ff88;
+      --accent-blue: #4a90d9;
+      --accent-purple: #b06cff;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      font-size: 16px;
+    }
+
+    body {
+      font-family: var(--pixel-font);
+      color: var(--text-primary);
+      background-color: var(--bg-dark);
+      line-height: 1.8;
+      -webkit-font-smoothing: none;
+      -moz-osx-font-smoothing: unset;
+      overflow-x: hidden;
+    }
+
+    a { color: var(--accent-gold); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    img {
+      max-width: 100%;
+      height: auto;
+      display: block;
+      image-rendering: pixelated;
+    }
+
+    /* ── Utility ───────────────────────────────────────── */
+    .container {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 0 20px;
+    }
+
+    .cta-btn {
+      display: inline-block;
+      font-family: var(--pixel-font);
+      font-size: 0.75rem;
+      color: var(--bg-dark);
+      background: var(--accent-gold);
+      padding: 16px 32px;
+      border: 3px solid #c9a020;
+      box-shadow:
+        4px 4px 0 #c9a020,
+        inset -2px -2px 0 rgba(0,0,0,0.15);
+      cursor: pointer;
+      transition: transform 0.1s, box-shadow 0.1s;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .cta-btn:hover {
+      transform: translate(-2px, -2px);
+      box-shadow:
+        6px 6px 0 #c9a020,
+        inset -2px -2px 0 rgba(0,0,0,0.15);
+      text-decoration: none;
+    }
+
+    .cta-btn:active {
+      transform: translate(2px, 2px);
+      box-shadow:
+        2px 2px 0 #c9a020,
+        inset -2px -2px 0 rgba(0,0,0,0.15);
+    }
+
+    .cta-btn--secondary {
+      background: var(--accent-purple);
+      border-color: #8a4fd9;
+      box-shadow: 4px 4px 0 #8a4fd9, inset -2px -2px 0 rgba(0,0,0,0.15);
+      color: #fff;
+    }
+    .cta-btn--secondary:hover {
+      box-shadow: 6px 6px 0 #8a4fd9, inset -2px -2px 0 rgba(0,0,0,0.15);
+    }
+    .cta-btn--secondary:active {
+      box-shadow: 2px 2px 0 #8a4fd9, inset -2px -2px 0 rgba(0,0,0,0.15);
+    }
+
+    .section-title {
+      font-size: 1rem;
+      text-align: center;
+      color: var(--accent-gold);
+      margin-bottom: 12px;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+
+    .section-subtitle {
+      font-size: 0.6rem;
+      text-align: center;
+      color: var(--text-secondary);
+      margin-bottom: 48px;
+      line-height: 2;
+    }
+
+    .pixel-border {
+      border: 3px solid var(--border-pixel);
+      box-shadow: 4px 4px 0 rgba(83, 52, 131, 0.4);
+    }
+
+    .placeholder-img {
+      width: 100%;
+      border-radius: 0;
+      background: var(--bg-panel);
+      border: 3px solid var(--border-pixel);
+      box-shadow: 4px 4px 0 rgba(83, 52, 131, 0.4);
+    }
+
+    /* ── Starfield background ─────────────────────────── */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      background:
+        radial-gradient(1px 1px at 10% 20%, rgba(255,255,255,0.4) 50%, transparent 100%),
+        radial-gradient(1px 1px at 30% 65%, rgba(255,255,255,0.3) 50%, transparent 100%),
+        radial-gradient(1px 1px at 50% 10%, rgba(255,255,255,0.5) 50%, transparent 100%),
+        radial-gradient(1px 1px at 70% 40%, rgba(255,255,255,0.3) 50%, transparent 100%),
+        radial-gradient(1px 1px at 85% 75%, rgba(255,255,255,0.4) 50%, transparent 100%),
+        radial-gradient(1px 1px at 15% 85%, rgba(255,255,255,0.2) 50%, transparent 100%),
+        radial-gradient(1px 1px at 60% 90%, rgba(255,255,255,0.3) 50%, transparent 100%),
+        radial-gradient(1px 1px at 90% 15%, rgba(255,255,255,0.4) 50%, transparent 100%),
+        radial-gradient(1px 1px at 40% 50%, rgba(255,255,255,0.2) 50%, transparent 100%),
+        radial-gradient(1px 1px at 25% 35%, rgba(255,255,255,0.3) 50%, transparent 100%),
+        radial-gradient(2px 2px at 5% 55%, rgba(245,200,66,0.3) 50%, transparent 100%),
+        radial-gradient(2px 2px at 95% 45%, rgba(176,108,255,0.3) 50%, transparent 100%);
+    }
+
+    /* ── Header / Nav ─────────────────────────────────── */
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: rgba(26, 26, 46, 0.95);
+      border-bottom: 2px solid var(--border-pixel);
+      backdrop-filter: blur(8px);
+      padding: 12px 0;
+    }
+
+    header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .logo {
+      font-size: 0.65rem;
+      color: var(--accent-gold);
+      letter-spacing: 1px;
+    }
+
+    .logo span {
+      color: var(--text-primary);
+    }
+
+    header .cta-btn {
+      font-size: 0.55rem;
+      padding: 10px 20px;
+    }
+
+    /* ── Hero ──────────────────────────────────────────── */
+    .hero {
+      padding: 80px 0 60px;
+      text-align: center;
+    }
+
+    .hero__badge {
+      display: inline-block;
+      font-size: 0.5rem;
+      color: var(--accent-green);
+      border: 2px solid var(--accent-green);
+      padding: 6px 14px;
+      margin-bottom: 28px;
+      animation: pulse-border 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse-border {
+      0%, 100% { border-color: var(--accent-green); color: var(--accent-green); }
+      50% { border-color: #22cc66; color: #22cc66; }
+    }
+
+    .hero__title {
+      font-size: 1.4rem;
+      color: var(--accent-gold);
+      margin-bottom: 20px;
+      text-shadow: 3px 3px 0 rgba(0,0,0,0.5);
+      line-height: 1.6;
+    }
+
+    .hero__tagline {
+      font-size: 0.65rem;
+      color: var(--text-secondary);
+      max-width: 600px;
+      margin: 0 auto 36px;
+      line-height: 2.2;
+    }
+
+    .hero__ctas {
+      display: flex;
+      gap: 16px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-bottom: 48px;
+    }
+
+    .hero__image-wrap {
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    .hero__image-caption {
+      font-size: 0.45rem;
+      color: var(--text-dim);
+      margin-top: 12px;
+      font-style: italic;
+    }
+
+    /* ── Features ──────────────────────────────────────── */
+    .features {
+      padding: 80px 0;
+    }
+
+    .features__grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 24px;
+    }
+
+    .feature-card {
+      background: var(--bg-panel);
+      border: 3px solid var(--border-pixel);
+      padding: 28px 20px;
+      box-shadow: 4px 4px 0 rgba(83, 52, 131, 0.3);
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .feature-card:hover {
+      transform: translate(-2px, -2px);
+      box-shadow: 6px 6px 0 rgba(83, 52, 131, 0.4);
+    }
+
+    .feature-card__icon {
+      font-size: 1.8rem;
+      margin-bottom: 16px;
+    }
+
+    .feature-card__title {
+      font-size: 0.65rem;
+      color: var(--accent-gold);
+      margin-bottom: 12px;
+      text-transform: uppercase;
+    }
+
+    .feature-card__desc {
+      font-size: 0.55rem;
+      color: var(--text-secondary);
+      line-height: 2;
+    }
+
+    /* ── Classes ───────────────────────────────────────── */
+    .classes {
+      padding: 80px 0;
+    }
+
+    .classes__row {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 16px;
+      margin-bottom: 48px;
+    }
+
+    .class-card {
+      background: var(--bg-panel);
+      border: 3px solid var(--border-pixel);
+      padding: 24px 12px;
+      text-align: center;
+      box-shadow: 4px 4px 0 rgba(83, 52, 131, 0.3);
+      transition: transform 0.15s, box-shadow 0.15s, border-color 0.2s;
+    }
+
+    .class-card:hover {
+      transform: translate(-2px, -2px);
+      box-shadow: 6px 6px 0 rgba(83, 52, 131, 0.4);
+      border-color: var(--border-light);
+    }
+
+    .class-card__icon {
+      font-size: 2rem;
+      margin-bottom: 12px;
+    }
+
+    .class-card__name {
+      font-size: 0.55rem;
+      color: var(--accent-gold);
+      margin-bottom: 8px;
+      text-transform: uppercase;
+    }
+
+    .class-card__role {
+      font-size: 0.45rem;
+      color: var(--text-secondary);
+      line-height: 1.8;
+    }
+
+    .classes__image-wrap {
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    .classes__image-caption {
+      font-size: 0.45rem;
+      color: var(--text-dim);
+      margin-top: 12px;
+      text-align: center;
+      font-style: italic;
+    }
+
+    /* ── How It Works ─────────────────────────────────── */
+    .how-it-works {
+      padding: 80px 0;
+    }
+
+    .steps {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 32px;
+      counter-reset: step;
+    }
+
+    .step {
+      text-align: center;
+      counter-increment: step;
+      position: relative;
+    }
+
+    .step__number {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 48px;
+      background: var(--accent-purple);
+      border: 3px solid #8a4fd9;
+      font-size: 0.8rem;
+      color: #fff;
+      margin-bottom: 16px;
+      box-shadow: 3px 3px 0 rgba(138, 79, 217, 0.4);
+    }
+
+    .step__title {
+      font-size: 0.6rem;
+      color: var(--accent-gold);
+      margin-bottom: 10px;
+      text-transform: uppercase;
+    }
+
+    .step__desc {
+      font-size: 0.5rem;
+      color: var(--text-secondary);
+      line-height: 2;
+    }
+
+    /* ── Final CTA ────────────────────────────────────── */
+    .final-cta {
+      padding: 80px 0;
+      text-align: center;
+    }
+
+    .final-cta__box {
+      background: var(--bg-panel);
+      border: 3px solid var(--border-pixel);
+      padding: 48px 32px;
+      box-shadow: 6px 6px 0 rgba(83, 52, 131, 0.4);
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
+    .final-cta__title {
+      font-size: 1rem;
+      color: var(--accent-gold);
+      margin-bottom: 16px;
+      text-shadow: 2px 2px 0 rgba(0,0,0,0.4);
+    }
+
+    .final-cta__text {
+      font-size: 0.55rem;
+      color: var(--text-secondary);
+      line-height: 2.2;
+      margin-bottom: 32px;
+    }
+
+    .final-cta__free {
+      font-size: 0.5rem;
+      color: var(--text-dim);
+      margin-top: 16px;
+    }
+
+    /* ── Footer ────────────────────────────────────────── */
+    footer {
+      border-top: 2px solid var(--border-pixel);
+      padding: 48px 0 32px;
+      text-align: center;
+    }
+
+    footer p {
+      font-size: 0.45rem;
+      color: var(--text-dim);
+      line-height: 2;
+    }
+
+    /* ── Contact / Collab ─────────────────────────────── */
+    .collab {
+      max-width: 560px;
+      margin: 0 auto 32px;
+      background: var(--bg-panel);
+      border: 2px solid var(--border-pixel);
+      padding: 28px 24px;
+      box-shadow: 3px 3px 0 rgba(83, 52, 131, 0.3);
+    }
+
+    .collab__heading {
+      font-size: 0.55rem;
+      color: var(--accent-purple);
+      margin-bottom: 10px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .collab__text {
+      font-size: 0.45rem;
+      color: var(--text-secondary);
+      line-height: 2.2;
+      margin-bottom: 24px;
+    }
+
+    /*
+     * Hex dungeon — flat-top hexagons sharing edges in a NE-SE-NE zigzag.
+     * Tile 0 is leftmost. Each subsequent tile shifts right by 75% of hex width
+     * (shared edge) and alternates up/down by 50% of hex height.
+     *
+     * Flat-top hex: width = W, height = W * sin(60°) ≈ W * 0.866
+     * Edge-sharing horizontal step = W * 0.75
+     * Vertical offset for neighbor = height * 0.5
+     */
+    .hex-dungeon {
+      --hex-w: 80px;
+      --hex-h: calc(var(--hex-w) * 0.866);
+      --hex-step-x: calc(var(--hex-w) * 0.75);
+      --hex-step-y: calc(var(--hex-h) * 0.5);
+      position: relative;
+      /* width = first hex full width + 3 steps; height = hex + one offset */
+      width: calc(var(--hex-w) + var(--hex-step-x) * 3);
+      height: calc(var(--hex-h) + var(--hex-step-y));
+      margin: 0 auto 16px;
+    }
+
+    .hex-tile {
+      position: absolute;
+      width: var(--hex-w);
+      height: var(--hex-h);
+      cursor: pointer;
+      transition: filter 0.15s;
+      /* Flat-top hexagon clip */
+      clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.6rem;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    /* Zigzag positions: NE, SE, NE pattern
+       Tile 0: col 0, top offset (up)
+       Tile 1: col 1, no offset (down = NE from 0)
+       Tile 2: col 2, top offset (up = SE from 1... wait)
+       Pattern: 0=up, 1=down, 2=up, 3=down  → NE, SE, NE */
+    .hex-tile:nth-child(1) { left: 0;                              top: 0; }
+    .hex-tile:nth-child(2) { left: var(--hex-step-x);              top: var(--hex-step-y); }
+    .hex-tile:nth-child(3) { left: calc(var(--hex-step-x) * 2);    top: 0; }
+    .hex-tile:nth-child(4) { left: calc(var(--hex-step-x) * 3);    top: var(--hex-step-y); }
+
+    .hex-tile--fog {
+      background: #2a2a44;
+    }
+
+    .hex-tile--monster {
+      background: #2e1a3e;
+    }
+
+    .hex-tile--active {
+      background: #3a1848;
+      animation: hex-pulse 1s ease-in-out infinite;
+    }
+
+    .hex-tile--slain {
+      background: #1a2e1a;
+      cursor: default;
+    }
+
+    .hex-tile--treasure {
+      background: linear-gradient(135deg, #3a2e10, #4a3a18);
+      cursor: default;
+      animation: hex-glow 1.5s ease-in-out infinite;
+    }
+
+    .hex-tile--locked {
+      pointer-events: none;
+      cursor: default;
+    }
+
+    .hex-tile:not(.hex-tile--slain):not(.hex-tile--treasure):not(.hex-tile--locked):hover {
+      filter: brightness(1.3);
+    }
+
+    .hex-tile:not(.hex-tile--slain):not(.hex-tile--treasure):not(.hex-tile--locked):active {
+      filter: brightness(0.8);
+    }
+
+    @keyframes hex-pulse {
+      0%, 100% { filter: brightness(1); }
+      50% { filter: brightness(1.25); }
+    }
+
+    @keyframes hex-glow {
+      0%, 100% { filter: brightness(1); }
+      50% { filter: brightness(1.4); }
+    }
+
+    @keyframes slay-flash {
+      0% { filter: brightness(3) saturate(0); }
+      50% { filter: brightness(2) saturate(0.5); }
+      100% { filter: brightness(1) saturate(1); }
+    }
+
+    .hex-tile--slay-anim {
+      animation: slay-flash 0.4s ease-out;
+    }
+
+    /* Status text under the dungeon */
+    .collab__status {
+      font-size: 0.45rem;
+      color: var(--text-dim);
+      margin-bottom: 8px;
+      min-height: 1.4em;
+      transition: color 0.3s;
+    }
+
+    .collab__status--victory {
+      color: var(--accent-gold);
+    }
+
+    /* Revealed treasure — email button injected by JS */
+    .collab__treasure {
+      margin-top: 16px;
+    }
+
+    .collab__treasure a {
+      display: inline-block;
+      font-family: var(--pixel-font);
+      font-size: 0.5rem;
+      padding: 12px 28px;
+      background: var(--accent-gold);
+      color: var(--bg-dark);
+      border: 3px solid #c9a020;
+      box-shadow: 3px 3px 0 #c9a020;
+      transition: transform 0.1s, box-shadow 0.1s;
+    }
+
+    .collab__treasure a:hover {
+      transform: translate(-1px, -1px);
+      box-shadow: 4px 4px 0 #c9a020;
+      text-decoration: none;
+    }
+
+    .collab__treasure a:active {
+      transform: translate(1px, 1px);
+      box-shadow: 2px 2px 0 #c9a020;
+    }
+
+    @media (max-width: 400px) {
+      .hex-dungeon { --hex-w: 60px; }
+      .hex-tile { font-size: 1.2rem; }
+    }
+
+    /* ── Responsive: Mobile ────────────────────────────── */
+    @media (max-width: 640px) {
+      .hero { padding: 48px 0 40px; }
+      .hero__title { font-size: 0.9rem; }
+      .hero__tagline { font-size: 0.55rem; }
+
+      .classes__row {
+        grid-template-columns: repeat(3, 1fr);
+      }
+
+      /* Let the last 2 cards center in a partial row */
+      .classes__row .class-card:nth-child(4),
+      .classes__row .class-card:nth-child(5) {
+        /* handled by auto-fit */
+      }
+
+      .feature-card { padding: 20px 16px; }
+
+      .steps { gap: 24px; }
+
+      .section-title { font-size: 0.8rem; }
+    }
+
+    @media (max-width: 400px) {
+      .hero__title { font-size: 0.75rem; }
+      .cta-btn { font-size: 0.6rem; padding: 14px 24px; }
+      header .cta-btn { font-size: 0.5rem; padding: 8px 14px; }
+      .classes__row { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    /* ── Responsive: Desktop ──────────────────────────── */
+    @media (min-width: 768px) {
+      .hero__title { font-size: 1.8rem; }
+      .hero__tagline { font-size: 0.75rem; }
+      .section-title { font-size: 1.2rem; }
+      .cta-btn { font-size: 0.8rem; padding: 18px 40px; }
+      .feature-card__desc { font-size: 0.6rem; }
+      .feature-card__title { font-size: 0.7rem; }
+      .step__desc { font-size: 0.55rem; }
+      .class-card__role { font-size: 0.5rem; }
+    }
+
+    /* ── Animations ────────────────────────────────────── */
+    @keyframes float {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
+
+    .float { animation: float 3s ease-in-out infinite; }
+
+    @keyframes shimmer {
+      0% { background-position: -200% center; }
+      100% { background-position: 200% center; }
+    }
+
+    .shimmer-text {
+      background: linear-gradient(
+        90deg,
+        var(--accent-gold) 0%,
+        #ffe08a 40%,
+        var(--accent-gold) 60%,
+        #ffe08a 100%
+      );
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      animation: shimmer 4s linear infinite;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- ═══════════ Header ═══════════ -->
+  <header>
+    <div class="container">
+      <div class="logo">IDLE PARTY <span>RPG</span></div>
+      <a href="https://play.idlepartyrpg.com" class="cta-btn">Play Now</a>
+    </div>
+  </header>
+
+  <!-- ═══════════ Hero ═══════════ -->
+  <section class="hero">
+    <div class="container">
+      <div class="hero__badge">Now in Early Access</div>
+      <h1 class="hero__title shimmer-text">Your Party Fights 24/7<br/>Even While You Sleep</h1>
+      <p class="hero__tagline">
+        A multiplayer idle RPG where your party never stops. Choose your class, team up with other players,
+        and explore a persistent world — your heroes fight, level up, and loot around the clock.
+      </p>
+      <div class="hero__ctas">
+        <a href="https://play.idlepartyrpg.com" class="cta-btn">Start Playing</a>
+        <a href="#features" class="cta-btn cta-btn--secondary">Learn More</a>
+      </div>
+      <div class="hero__image-wrap">
+        <!--
+          DESIRED IMAGE: A pixel-art battle scene showing a party of 5 heroes (knight with shield, archer,
+          robed priest, mage with staff, bard with lute) fighting goblins and wolves on a hex-grid battlefield.
+          Dark fantasy style, vibrant pixel art, 16-bit aesthetic. The heroes are arranged in a 3x3 grid formation
+          with floating HP bars above each character. Background shows a dark forest hex map.
+        -->
+        <img
+          src="https://placehold.co/720x360/16213e/7b5ea7?text=Battle+Scene+%E2%9A%94%EF%B8%8F&font=press-start-2p"
+          alt="A pixel-art battle scene: a party of 5 heroes (knight, archer, priest, mage, bard) in formation fighting goblins and wolves on a hex-grid battlefield with floating HP bars, dark fantasy forest background, 16-bit retro style"
+          class="placeholder-img"
+        />
+        <p class="hero__image-caption">Real-time party combat in a persistent world</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════ Features ═══════════ -->
+  <section class="features" id="features">
+    <div class="container">
+      <h2 class="section-title">Why Idle Party?</h2>
+      <p class="section-subtitle">A multiplayer idle RPG that respects your time — and rewards it.</p>
+      <div class="features__grid">
+
+        <div class="feature-card">
+          <div class="feature-card__icon float">&#x1F319;</div>
+          <h3 class="feature-card__title">Always Running</h3>
+          <p class="feature-card__desc">
+            Your party keeps fighting, moving, and earning XP 24/7. Close the browser, go to sleep
+            — come back to progress waiting for you.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <div class="feature-card__icon float" style="animation-delay: 0.4s">&#x2694;&#xFE0F;</div>
+          <h3 class="feature-card__title">Party Up</h3>
+          <p class="feature-card__desc">
+            Weak solo, strong together. Every class shines in a group. Team up with friends
+            and build the ultimate party composition.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <div class="feature-card__icon float" style="animation-delay: 0.8s">&#x1F5FA;&#xFE0F;</div>
+          <h3 class="feature-card__title">Explore & Discover</h3>
+          <p class="feature-card__desc">
+            Traverse a world full of towns, forests, crystal caves, and more.
+            Unlock new zones and discover hidden rooms.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <div class="feature-card__icon float" style="animation-delay: 1.2s">&#x1F4A0;</div>
+          <h3 class="feature-card__title">Unlock Skills</h3>
+          <p class="feature-card__desc">
+            Each class has a unique skill tree with passives and actives to unlock.
+            Customize your loadout and experiment with powerful party synergies.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <div class="feature-card__icon float" style="animation-delay: 1.6s">&#x1F4AC;</div>
+          <h3 class="feature-card__title">Social & Guilds</h3>
+          <p class="feature-card__desc">
+            Chat with friends, join guilds, trade items, and form parties. A full social
+            experience without the grind pressure.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <div class="feature-card__icon float" style="animation-delay: 2.0s">&#x1F9E9;</div>
+          <h3 class="feature-card__title">Real Challenges</h3>
+          <p class="feature-card__desc">
+            Tougher zones demand the right mix of classes. Swap party members, rethink
+            your formation, and strategize with other players to push deeper.
+          </p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════ Classes ═══════════ -->
+  <section class="classes" id="classes">
+    <div class="container">
+      <h2 class="section-title">Choose Your Class</h2>
+      <p class="section-subtitle">Five heroes. Endless party combinations. Every class is built to complement the others.</p>
+
+      <div class="classes__row">
+        <div class="class-card">
+          <div class="class-card__icon">&#x1F6E1;&#xFE0F;</div>
+          <h3 class="class-card__name">Knight</h3>
+          <p class="class-card__role">Tank. Absorbs damage so others can deal it.</p>
+        </div>
+        <div class="class-card">
+          <div class="class-card__icon">&#x1F3F9;</div>
+          <h3 class="class-card__name">Archer</h3>
+          <p class="class-card__role">DPS. Crits hard. Shreds single targets.</p>
+        </div>
+        <div class="class-card">
+          <div class="class-card__icon">&#x2625;</div>
+          <h3 class="class-card__name">Priest</h3>
+          <p class="class-card__role">Healer. Keeps the party alive and shields allies.</p>
+        </div>
+        <div class="class-card">
+          <div class="class-card__icon">&#x1FA84;</div>
+          <h3 class="class-card__name">Mage</h3>
+          <p class="class-card__role">Nuker. Massive magical burst damage.</p>
+        </div>
+        <div class="class-card">
+          <div class="class-card__icon">&#x1F3B5;</div>
+          <h3 class="class-card__name">Bard</h3>
+          <p class="class-card__role">Buffer. Makes everyone hit harder.</p>
+        </div>
+      </div>
+
+      <div class="classes__image-wrap">
+        <!--
+          DESIRED IMAGE: A pixel-art hex world map showing a party token moving across colorful hexagonal tiles.
+          Different terrain types visible: green forest tiles, grey mountain tiles, blue water tiles, and a
+          warm-toned town tile with a small building icon. Fog of war partially obscures unexplored areas.
+          Top-down view, flat-top hexagons, retro 16-bit RPG style with a dark purple/blue background.
+        -->
+        <img
+          src="https://placehold.co/720x360/16213e/7b5ea7?text=Hex+World+Map+%F0%9F%97%BA%EF%B8%8F&font=press-start-2p"
+          alt="A pixel-art hex world map with a party token moving across colorful hexagonal terrain tiles (forests, mountains, water, towns) with fog of war on unexplored areas, top-down flat-top hexagons, retro 16-bit RPG style"
+          class="placeholder-img"
+        />
+        <p class="classes__image-caption">Explore diverse zones — forests, caves, towns, and more</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════ How It Works ═══════════ -->
+  <section class="how-it-works" id="how">
+    <div class="container">
+      <h2 class="section-title">Get Started in Seconds</h2>
+      <p class="section-subtitle">No download. No install. Just play.</p>
+
+      <div class="steps">
+        <div class="step">
+          <div class="step__number">1</div>
+          <h3 class="step__title">Sign In</h3>
+          <p class="step__desc">Enter your email. Click a magic link. That's it — no passwords to remember.</p>
+        </div>
+        <div class="step">
+          <div class="step__number">2</div>
+          <h3 class="step__title">Pick a Class</h3>
+          <p class="step__desc">Choose from Knight, Archer, Priest, Mage, or Bard. Each plays a different role in the party.</p>
+        </div>
+        <div class="step">
+          <div class="step__number">3</div>
+          <h3 class="step__title">Party Up</h3>
+          <p class="step__desc">Invite friends and build your party. Position your team on the combat grid for maximum synergy.</p>
+        </div>
+        <div class="step">
+          <div class="step__number">4</div>
+          <h3 class="step__title">Let It Ride</h3>
+          <p class="step__desc">Your party fights and explores non-stop. Check in whenever you want — your progress never pauses.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════ Final CTA ═══════════ -->
+  <section class="final-cta">
+    <div class="container">
+      <div class="final-cta__box">
+        <h2 class="final-cta__title shimmer-text">Start Your Adventure</h2>
+        <p class="final-cta__text">
+          Your party is waiting. Jump into a persistent world, team up with other players,
+          and watch your heroes grow — even when you're away.
+        </p>
+        <a href="https://play.idlepartyrpg.com" class="cta-btn">Play Idle Party RPG</a>
+        <p class="final-cta__free">Free to play. No download required. Web &amp; mobile.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════ Footer ═══════════ -->
+  <footer>
+    <div class="container">
+
+      <div class="collab">
+        <h3 class="collab__heading">Want to Collaborate?</h3>
+        <p class="collab__text">
+          Publisher, designer, developer, pixel artist &mdash; if you're into indie games
+          and want to help bring Idle Party RPG to the next level, we'd love to hear from you.
+          Slay the monsters to claim the treasure and reveal our contact.
+        </p>
+        <div class="hex-dungeon" id="hex-dungeon"></div>
+        <div class="collab__status" id="collab-status"></div>
+        <div id="collab-treasure"></div>
+      </div>
+
+      <p>&copy; 2026 Idle Party RPG &mdash; <a href="https://play.idlepartyrpg.com">play.idlepartyrpg.com</a></p>
+    </div>
+  </footer>
+
+  <script>
+    (function() {
+      /* ── XOR-encoded contact (never plaintext in source) ── */
+      var _k = [7,13,3,19,11,5,17,2,23,9,14,6,21,8,4,16,10,1,20,12,15];
+      var _c = [96,108,110,118,75,108,117,110,114,121,111,116,97,113,118,96,109,47,119,99,98];
+      function _d() { return _c.map(function(v,i){ return String.fromCharCode(v ^ _k[i]); }).join(''); }
+
+      /* ── Dungeon state ── */
+      var stages = [
+        { icon: '\uD83D\uDC80', name: 'Skeleton',  slainIcon: '\u2620\uFE0F' },
+        { icon: '\uD83D\uDC32', name: 'Drake',     slainIcon: '\uD83D\uDD25' },
+        { icon: '\uD83E\uDDD9', name: 'Sorcerer',  slainIcon: '\u2728'       },
+        { icon: '\u2753',       name: 'Treasure',   slainIcon: '\u2753'       }
+      ];
+      var current = 0; // index of the next tile to slay
+      var dungeon = document.getElementById('hex-dungeon');
+      var status = document.getElementById('collab-status');
+      var treasureEl = document.getElementById('collab-treasure');
+
+      /* ── Build tiles ── */
+      var tiles = [];
+      stages.forEach(function(stage, i) {
+        var tile = document.createElement('div');
+        tile.className = 'hex-tile';
+
+        if (i === 0) {
+          tile.classList.add('hex-tile--active');
+          tile.textContent = stage.icon;
+        } else {
+          tile.classList.add('hex-tile--fog', 'hex-tile--locked');
+          tile.textContent = '\uD83C\uDF2B\uFE0F';
+        }
+
+        tile.addEventListener('click', function() { slayTile(i); });
+
+        dungeon.appendChild(tile);
+        tiles.push(tile);
+      });
+
+      status.textContent = 'Click the Skeleton to begin...';
+
+      /* ── Slay logic ── */
+      function slayTile(idx) {
+        if (idx !== current) return;
+        if (current >= stages.length) return;
+
+        var tile = tiles[idx];
+        var stage = stages[idx];
+
+        // Flash animation
+        tile.classList.remove('hex-tile--active');
+        tile.classList.add('hex-tile--slay-anim');
+
+        setTimeout(function() {
+          tile.classList.remove('hex-tile--slay-anim', 'hex-tile--monster', 'hex-tile--fog');
+          tile.classList.add('hex-tile--slain');
+          tile.textContent = stage.slainIcon;
+
+          current++;
+
+          if (current < stages.length) {
+            // Reveal next tile
+            var next = tiles[current];
+            var nextStage = stages[current];
+
+            if (current === stages.length - 1) {
+              // This is the treasure tile — don't show as monster
+              revealTreasure(next);
+            } else {
+              // Reveal the next monster
+              next.classList.remove('hex-tile--fog', 'hex-tile--locked');
+              next.classList.add('hex-tile--active');
+              next.textContent = nextStage.icon;
+              status.textContent = 'A ' + nextStage.name + ' appears!';
+            }
+          }
+        }, 350);
+
+        // Immediate status feedback
+        status.textContent = stage.name + ' slain!';
+      }
+
+      /* ── Reveal treasure (final tile) ── */
+      function revealTreasure(tile) {
+        tile.classList.remove('hex-tile--fog', 'hex-tile--locked');
+        tile.classList.add('hex-tile--treasure');
+        tile.textContent = '\u2709\uFE0F';
+
+        status.textContent = 'Treasure unlocked!';
+        status.classList.add('collab__status--victory');
+
+        // Build the email link (only now does the address enter the DOM)
+        var addr = _d();
+        treasureEl.className = 'collab__treasure';
+        var link = document.createElement('a');
+        link.href = 'ma' + 'il' + 'to:' + addr;
+        link.textContent = '\u2709\uFE0F  Send Us an Email';
+        treasureEl.appendChild(link);
+
+        current = stages.length; // done
+      }
+    })();
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Standalone `landing/index.html` — self-contained, no build step, same retro RPG aesthetic as the game
- Hero section, 6 feature cards, 5 class showcase cards, "How It Works" steps, and dual CTAs to play.idlepartyrpg.com
- Footer collaboration section with a hex-tile dungeon mini-game (click 3 monsters in sequence to reveal contact) — email is XOR-encoded and only injected into the DOM after completing the gauntlet, never appears as plaintext in source
- Fully responsive: mobile-first with desktop scaling at 768px+
- Placeholder images via placehold.co with detailed alt text descriptions for future asset generation

## Test plan
- [ ] Open `landing/index.html` directly in a browser — verify layout, fonts, animations
- [ ] Test on mobile viewport (Chrome DevTools or real device) — verify responsive breakpoints
- [ ] Click through the hex dungeon in the footer — skeleton → drake → sorcerer → treasure → email button appears
- [ ] Verify "Send Us an Email" mailto link works and points to correct address
- [ ] View page source / search for email string — confirm it's not in plaintext anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)