### PR TITLE
Equipment update v1 polish and fixes

### DIFF
--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -225,17 +225,41 @@ export class AdminApp {
       this.versions = versionsData.versions;
       this.activeVersionId = versionsData.activeVersionId ?? null;
 
-      // Always view a version — select the active one (or first available)
-      const initialVersionId = this.activeVersionId ?? this.versions[0]?.id ?? null;
+      // Restore version from sessionStorage, or default to active version
+      const savedVersionId = sessionStorage.getItem('adminVersionId');
+      const initialVersionId = (savedVersionId && this.versions.some(v => v.id === savedVersionId))
+        ? savedVersionId
+        : (this.activeVersionId ?? this.versions[0]?.id ?? null);
       if (initialVersionId) {
         await this.selectVersion(initialVersionId);
       }
 
-      // Restore last active tab from sessionStorage
-      const saved = sessionStorage.getItem('adminTab') as TabId | null;
-      if (saved && TABS.some(t => t.id === saved)) {
-        this.activeTab = saved;
+      // Restore tab from URL path, falling back to sessionStorage
+      const tabFromUrl = this.getTabFromUrl();
+      if (tabFromUrl) {
+        this.activeTab = tabFromUrl;
+      } else {
+        const saved = sessionStorage.getItem('adminTab') as TabId | null;
+        if (saved && TABS.some(t => t.id === saved)) {
+          this.activeTab = saved;
+        }
       }
+
+      // Listen for browser back/forward navigation
+      const handleNavigation = () => {
+        const tab = this.getTabFromUrl();
+        if (tab && tab !== this.activeTab) {
+          if (this.activeTab === 'map') this.cleanupMapCanvas();
+          this.activeTab = tab;
+          this.container.querySelectorAll('.admin-sidebar-btn[data-tab]').forEach(btn => {
+            const el = btn as HTMLElement;
+            el.classList.toggle('active', el.dataset.tab === tab);
+          });
+          this.renderTabContent();
+        }
+      };
+      window.addEventListener('popstate', handleNavigation);
+      window.addEventListener('hashchange', handleNavigation);
 
       this.renderShell();
     } catch (err) {
@@ -330,7 +354,50 @@ export class AdminApp {
 
     document.getElementById('admin-refresh')?.addEventListener('click', () => this.refresh());
 
+    // Set URL to reflect initial tab (use replaceState to avoid extra history entry)
+    const isDev = window.location.pathname.includes('admin.html');
+    if (isDev) {
+      if (!window.location.hash) window.location.hash = this.activeTab;
+    } else {
+      const url = `/admin/${this.activeTab}`;
+      if (window.location.pathname !== url) {
+        history.replaceState(null, '', url);
+      }
+    }
+
     this.renderTabContent();
+  }
+
+  /** Extract the active tab from the URL path (e.g. /admin/sets → 'sets'). */
+  private getTabFromUrl(): TabId | null {
+    const path = window.location.pathname;
+    // Match /admin/{tab} or /admin.html#{tab} (dev mode)
+    const match = path.match(/\/admin\/(\w[\w-]*)/) ?? path.match(/\/admin\.html#(\w[\w-]*)/);
+    if (match) {
+      const candidate = match[1] as TabId;
+      if (TABS.some(t => t.id === candidate)) return candidate;
+    }
+    // Also check hash for dev mode
+    if (window.location.hash) {
+      const hashTab = window.location.hash.replace('#', '') as TabId;
+      if (TABS.some(t => t.id === hashTab)) return hashTab;
+    }
+    return null;
+  }
+
+  /** Update the URL to reflect the current tab. */
+  private pushTabUrl(tabId: TabId): void {
+    // In dev mode (Vite on admin.html), use hash routing
+    // In prod mode (/admin/*), use path routing
+    const isDev = window.location.pathname.includes('admin.html');
+    if (isDev) {
+      window.location.hash = tabId;
+    } else {
+      const url = `/admin/${tabId}`;
+      if (window.location.pathname !== url) {
+        history.pushState(null, '', url);
+      }
+    }
   }
 
   private switchTab(tabId: TabId): void {
@@ -343,6 +410,7 @@ export class AdminApp {
 
     this.activeTab = tabId;
     sessionStorage.setItem('adminTab', tabId);
+    this.pushTabUrl(tabId);
 
     // Update active class on sidebar buttons
     this.container.querySelectorAll('.admin-sidebar-btn[data-tab]').forEach(btn => {
@@ -2818,6 +2886,7 @@ export class AdminApp {
 
   private async selectVersion(versionId: string): Promise<void> {
     this.selectedVersionId = versionId;
+    sessionStorage.setItem('adminVersionId', versionId);
     try {
       const snapshot = await this.fetchAdmin<ContentData>(`/api/admin/versions/${versionId}/content`);
       this.versionContent = snapshot;

--- a/client/src/screens/ItemsScreen.ts
+++ b/client/src/screens/ItemsScreen.ts
@@ -1,24 +1,10 @@
 import type { GameClient } from '../network/GameClient';
 import type { ServerStateMessage, ServerEquipBlockedMessage } from '@idle-party-rpg/shared';
-import { getItemEffectText, CLASS_ICONS, UNKNOWN_CLASS_ICON, getSetInfoForItem, getSetBonusText } from '@idle-party-rpg/shared';
+import { CLASS_ICONS, UNKNOWN_CLASS_ICON } from '@idle-party-rpg/shared';
 import type { EquipSlot, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
 import type { Screen } from './ScreenManager';
-
-const SLOT_LABELS: Record<EquipSlot, string> = {
-  head: 'Head',
-  shoulders: 'Shoulders',
-  chest: 'Chest',
-  bracers: 'Bracers',
-  gloves: 'Hands',
-  mainhand: 'Main Hand',
-  offhand: 'Offhand',
-  twohanded: 'Two-Handed',
-  foot: 'Feet',
-  ring: 'Ring',
-  necklace: 'Necklace',
-  back: 'Back',
-  relic: 'Relic',
-};
+import { RARITY_ORDER, renderItemIcon, renderEmptySlotIcon } from '../ui/ItemIcon';
+import { renderItemPopupContent } from '../ui/ItemPopup';
 
 /** Left column slots (top to bottom). */
 const LEFT_SLOTS: EquipSlot[] = ['head', 'shoulders', 'chest', 'gloves', 'foot'];
@@ -26,38 +12,7 @@ const LEFT_SLOTS: EquipSlot[] = ['head', 'shoulders', 'chest', 'gloves', 'foot']
 /** Right column slots (top to bottom). */
 const RIGHT_SLOTS: EquipSlot[] = ['back', 'necklace', 'bracers', 'ring', 'relic'];
 
-const RARITY_COLORS: Record<string, string> = {
-  janky: '#808080',
-  common: '#e8e8e8',
-  uncommon: '#66bb6a',
-  rare: '#4fc3f7',
-  epic: '#ee66e3',
-  legendary: '#9233df',
-  heirloom: '#e9bc18',
-};
-
-const EMPTY_SLOT_COLOR = '#333333';
-
-const SLOT_ICONS: Record<string, string> = {
-  head: 'H', shoulders: 'S', chest: 'C', bracers: 'B', gloves: 'G',
-  mainhand: 'M', offhand: 'O', twohanded: '2H', foot: 'F',
-  ring: 'R', necklace: 'N', back: 'K', relic: 'L',
-};
-
-const SHINY_RARITIES = new Set(['epic', 'legendary', 'heirloom']);
-
 type SortMode = 'rarity' | 'type' | 'newest';
-
-const RARITY_ORDER: Record<string, number> = {
-  heirloom: 0, legendary: 1, epic: 2, rare: 3, uncommon: 4, common: 5, janky: 6,
-};
-
-function getItemInitials(name: string): string {
-  const words = name.split(/\s+/).filter(Boolean);
-  if (words.length === 0) return '?';
-  if (words.length === 1) return words[0].substring(0, 2).toUpperCase();
-  return (words[0][0] + words[1][0]).toUpperCase();
-}
 
 function injectItemsStyles(): void {
   if (document.getElementById('items-screen-styles')) return;
@@ -518,21 +473,16 @@ export class ItemsScreen implements Screen {
     const renderSlotSquare = (slot: EquipSlot) => {
       const itemId = char.equipment[slot];
       const def = itemId ? this.itemDefs[itemId] : null;
-      const bgColor = def ? (RARITY_COLORS[def.rarity] ?? '#e8e8e8') : EMPTY_SLOT_COLOR;
-      const shinyClass = def && SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
-      const hasSet = def && itemId ? this.getItemSetId(itemId) : false;
-
-      let inner = '';
-      if (def) {
-        const initials = getItemInitials(def.name);
-        inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
-          <span class="item-square-initials">${initials}</span>`;
-        if (hasSet) inner += `<span class="item-square-set">S</span>`;
-      } else {
-        inner = `<span class="item-square-initials" style="color:rgba(255,255,255,0.3)">${SLOT_ICONS[slot] ?? ''}</span>`;
+      const dataAttrs: Record<string, string> = { slot, 'item-id': itemId ?? '' };
+      if (def && itemId) {
+        return renderItemIcon(itemId, def, {
+          showSetIndicator: true,
+          setDefs: this.setDefs,
+          extraClass: 'items-equip-slot-square',
+          dataAttrs,
+        });
       }
-
-      return `<div class="item-square items-equip-slot-square${shinyClass}" data-slot="${slot}" data-item-id="${itemId ?? ''}" title="${def ? def.name : SLOT_LABELS[slot]}" style="background:${bgColor}">${inner}</div>`;
+      return renderEmptySlotIcon(slot, { extraClass: 'items-equip-slot-square', dataAttrs });
     };
 
     const leftCol = this.slotsContainer.querySelector('.items-equip-left')!;
@@ -601,86 +551,28 @@ export class ItemsScreen implements Screen {
     this.inventoryGrid.innerHTML = filtered.map(([itemId, count]) => {
       const def = this.itemDefs[itemId];
       if (!def) return '';
-      const bgColor = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
-      const shinyClass = SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
-      const initials = getItemInitials(def.name);
-      const slotIcon = def.equipSlot ? (SLOT_ICONS[def.equipSlot] ?? '') : '';
-      const hasSet = this.getItemSetId(itemId);
-
-      let inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" alt="">
-        <span class="item-square-initials">${initials}</span>`;
-      if (hasSet) inner += `<span class="item-square-set">S</span>`;
-      if (count > 1) inner += `<span class="item-square-qty">${count}</span>`;
-      if (slotIcon) inner += `<span class="item-square-slot-icon">${slotIcon}</span>`;
-
-      return `<div class="item-square${shinyClass}" data-item="${itemId}" title="${def.name}" style="background:${bgColor}">${inner}</div>`;
+      return renderItemIcon(itemId, def, {
+        qty: count,
+        showSlotIcon: true,
+        showSetIndicator: true,
+        setDefs: this.setDefs,
+        dataAttrs: { item: itemId },
+      });
     }).join('');
-  }
-
-  private getItemSetId(itemId: string): string | null {
-    for (const set of Object.values(this.setDefs)) {
-      if (set.itemIds.includes(itemId)) return set.id;
-    }
-    return null;
   }
 
   private showItemPopup(itemId: string, context: 'equipped' | 'inventory', equippedSlot?: EquipSlot): void {
     const def = this.itemDefs[itemId];
     if (!def) return;
 
-    const bgColor = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
-    const rarityColor = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
-    const initials = getItemInitials(def.name);
-
-    // Build stat lines
-    const statLines: string[] = [];
-    const effect = getItemEffectText(def);
-    if (effect && effect !== 'Material' && effect !== 'No bonus') {
-      statLines.push(`<div><span class="stat-label">Effect</span><span>${effect}</span></div>`);
-    }
-    if (def.equipSlot) {
-      statLines.push(`<div><span class="stat-label">Slot</span><span>${SLOT_LABELS[def.equipSlot] ?? def.equipSlot}</span></div>`);
-    } else {
-      statLines.push(`<div><span class="stat-label">Type</span><span>Material</span></div>`);
-    }
-    statLines.push(`<div><span class="stat-label">Rarity</span><span style="color:${rarityColor}">${def.rarity.charAt(0).toUpperCase() + def.rarity.slice(1)}</span></div>`);
-    if (def.value != null && def.value > 0) {
-      statLines.push(`<div><span class="stat-label">Value</span><span>${def.value}g</span></div>`);
-    }
-    if (def.classRestriction && def.classRestriction.length > 0) {
-      statLines.push(`<div><span class="stat-label">Class</span><span>${def.classRestriction.join(', ')}</span></div>`);
-    }
-
-    // Set info
+    // Build owned/equipped sets for set info display
     const ownedItemIds = new Set<string>(
       Object.entries(this.lastInventory).filter(([, c]) => c > 0).map(([id]) => id)
     );
     const equippedItemIds = new Set<string>(
       Object.values(this.lastEquipment).filter((id): id is string => id != null)
     );
-    // Owned should also include equipped items
     for (const eid of equippedItemIds) ownedItemIds.add(eid);
-
-    const setInfo = getSetInfoForItem(itemId, this.setDefs, ownedItemIds, equippedItemIds);
-    let setHtml = '';
-    if (setInfo) {
-      const piecesHtml = setInfo.set.itemIds.map(pieceId => {
-        const pieceDef = this.itemDefs[pieceId];
-        const pieceName = pieceDef?.name ?? pieceId;
-        const isEquipped = equippedItemIds.has(pieceId);
-        const isOwned = ownedItemIds.has(pieceId);
-        const cssClass = isEquipped ? 'equipped' : isOwned ? 'owned' : '';
-        const check = isOwned ? (isEquipped ? '&#9745; ' : '&#9744; ') : '&#9744; ';
-        return `<div class="item-popup-set-piece ${cssClass}">${check}${pieceName}</div>`;
-      }).join('');
-      const bonusText = getSetBonusText(setInfo.set.bonuses);
-      setHtml = `
-        <div class="item-popup-set-section">
-          <div class="item-popup-set-name">${setInfo.set.name} (${setInfo.equippedCount}/${setInfo.set.itemIds.length})</div>
-          <div class="item-popup-set-pieces">${piecesHtml}</div>
-          <div class="item-popup-set-bonus">Set bonus: ${bonusText}</div>
-        </div>`;
-    }
 
     // Action buttons
     const count = this.lastInventory[itemId] ?? 0;
@@ -694,20 +586,17 @@ export class ItemsScreen implements Screen {
       actionsHtml += `<button class="popup-action-destroy danger" data-item="${itemId}" data-max="${count}">Destroy</button>`;
     }
 
-    const shinyClass = SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
+    const popupContent = renderItemPopupContent(def, {
+      itemDefs: this.itemDefs,
+      setDefs: this.setDefs,
+      ownedItemIds,
+      equippedItemIds,
+      actionsHtml,
+    });
 
     this.modalOverlay.innerHTML = `
       <div class="item-popup-overlay">
-        <div class="item-popup">
-          <div class="item-popup-artwork${shinyClass}" style="background:${bgColor}">
-            <img src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
-            <span class="item-popup-initials">${initials}</span>
-          </div>
-          <div class="item-popup-name" style="color:${rarityColor}">${def.name}</div>
-          <div class="item-popup-stats">${statLines.join('')}</div>
-          ${setHtml}
-          <div class="item-popup-actions">${actionsHtml}</div>
-        </div>
+        <div class="item-popup">${popupContent}</div>
       </div>
     `;
     this.modalOverlay.style.display = 'flex';

--- a/client/src/screens/ItemsScreen.ts
+++ b/client/src/screens/ItemsScreen.ts
@@ -73,7 +73,8 @@ function injectItemsStyles(): void {
       display: flex;
       align-items: center;
       justify-content: center;
-      border: 2px solid transparent;
+      border: 2px solid rgba(180,180,180,0.25);
+      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3);
       box-sizing: border-box;
       min-width: 0;
     }
@@ -129,19 +130,28 @@ function injectItemsStyles(): void {
       line-height: 1;
     }
 
-    @keyframes item-shiny-border {
-      0%   { border-color: rgba(255,255,255,0.3); }
-      50%  { border-color: rgba(255,255,255,0.9); }
-      100% { border-color: rgba(255,255,255,0.3); }
+    @keyframes item-border-epic {
+      0%, 100% { border-color: #ee66e3; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(238,102,227,0.3); }
+      50% { border-color: #ff99f0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 6px rgba(255,153,240,0.5); }
+    }
+    @keyframes item-border-legendary {
+      0% { border-color: #9233df; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(146,51,223,0.3); }
+      33% { border-color: #c77dff; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 6px rgba(199,125,255,0.5); }
+      66% { border-color: #e0aaff; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 8px rgba(224,170,255,0.6); }
+      100% { border-color: #9233df; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(146,51,223,0.3); }
+    }
+    @keyframes item-border-heirloom {
+      0%, 100% { border-color: #e9bc18; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(233,188,24,0.3); }
+      50% { border-color: #fff176; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 8px rgba(255,241,118,0.6); }
     }
     .item-rarity-epic {
-      animation: item-shiny-border 2.5s ease-in-out infinite;
+      animation: item-border-epic 2s ease-in-out infinite;
     }
     .item-rarity-legendary {
-      animation: item-shiny-border 1.8s ease-in-out infinite;
+      animation: item-border-legendary 3s ease-in-out infinite;
     }
     .item-rarity-heirloom {
-      animation: item-shiny-border 1.2s ease-in-out infinite;
+      animation: item-border-heirloom 2.5s ease-in-out infinite;
     }
 
     .item-popup-overlay {
@@ -293,8 +303,8 @@ function injectItemsStyles(): void {
     }
 
     .items-equip-slot-square {
-      width: 40px;
-      height: 40px;
+      width: 44px;
+      height: 44px;
     }
 
     @media (min-width: 768px) {
@@ -303,8 +313,8 @@ function injectItemsStyles(): void {
         gap: 6px;
       }
       .items-equip-slot-square {
-        width: 48px;
-        height: 48px;
+        width: 52px;
+        height: 52px;
       }
       .item-square-initials {
         font-size: 16px;
@@ -515,7 +525,7 @@ export class ItemsScreen implements Screen {
       let inner = '';
       if (def) {
         const initials = getItemInitials(def.name);
-        inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" alt="">
+        inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
           <span class="item-square-initials">${initials}</span>`;
         if (hasSet) inner += `<span class="item-square-set">S</span>`;
       } else {
@@ -690,7 +700,7 @@ export class ItemsScreen implements Screen {
       <div class="item-popup-overlay">
         <div class="item-popup">
           <div class="item-popup-artwork${shinyClass}" style="background:${bgColor}">
-            <img src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" alt="">
+            <img src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
             <span class="item-popup-initials">${initials}</span>
           </div>
           <div class="item-popup-name" style="color:${rarityColor}">${def.name}</div>

--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -1,23 +1,27 @@
 export const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.04.03.2',
+    notes: [
+      'Item icons now show artwork when available, with rarity-colored frames',
+      'Higher rarity items have animated glowing borders',
+      'Equipment silhouette is larger and easier to read',
+      'Viewing another player shows the same equipment layout as your own inventory',
+      'Clicking an item on another player shows full item details',
+    ],
+  },
+  {
     version: '2026.04.03.1',
     notes: [
-      'Fixed bug where rings with two-handed flag could corrupt equipment slots (#114)',
-      'Two-handed weapons now use a dedicated equip slot instead of a boolean flag',
+      'Fixed bug where rings could corrupt equipment slots',
+      'Two-handed weapons now use a dedicated equipment slot',
       'Removed dodge chance from equipment — Bard Nimble skill remains',
       'Added Magic Resistance (MR) stat to equipment — reduces magical damage',
-      'Class restrictions can now apply to multiple classes',
-      'Items now have a gold value',
-      'Items screen reworked: square grid icons with artwork support, rarity backgrounds, animated borders',
-      'Item popup modal shows full details, set info, and actions',
+      'Items screen reworked: square grid icons with rarity backgrounds and animated borders',
+      'Click any item to see full details, stats, and set info',
       'Inventory search and sort (by rarity, type, or newest)',
       'Item sets: equip all pieces for bonus stats',
       'Shops: buy and sell items at designated rooms',
-      'Admin: item editor is now a popup modal with artwork upload',
-      'Admin: class restriction is now a checklist',
-      'Admin: new Sets and Shops management tabs',
-      'Admin: items show value, set, and artwork in list view',
-      'View player profile now shows equipment as square icons',
+      'Items now have a gold value',
     ],
   },
   {

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -2023,57 +2023,95 @@ export class SocialScreen implements Screen {
     def: ItemDefinition,
     setDefs: Record<string, SetDefinition>,
     equippedItemIds: Set<string>,
-    anchor: HTMLElement,
+    _anchor: HTMLElement,
   ): void {
     // Remove any existing popup
-    document.querySelector('.profile-item-popup')?.remove();
+    document.querySelector('.profile-item-popup-overlay')?.remove();
 
     const RARITY_COLORS: Record<string, string> = {
       janky: '#808080', common: '#e8e8e8', uncommon: '#66bb6a', rare: '#4fc3f7',
       epic: '#ee66e3', legendary: '#9233df', heirloom: '#e9bc18',
     };
+    const SLOT_LABELS: Record<string, string> = {
+      head: 'Head', shoulders: 'Shoulders', chest: 'Chest', bracers: 'Bracers',
+      gloves: 'Hands', mainhand: 'Main Hand', offhand: 'Offhand', twohanded: 'Two-Handed',
+      foot: 'Feet', ring: 'Ring', necklace: 'Necklace', back: 'Back', relic: 'Relic',
+    };
+    const SHINY_RARITIES = new Set(['epic', 'legendary', 'heirloom']);
+
     const color = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
     const effect = getItemEffectText(def);
-    const setInfo = getSetInfoForItem(def.id, setDefs, equippedItemIds, equippedItemIds);
+    const initials = (() => {
+      const words = def.name.split(/\s+/).filter(Boolean);
+      if (words.length === 0) return '?';
+      if (words.length === 1) return words[0].substring(0, 2).toUpperCase();
+      return (words[0][0] + words[1][0]).toUpperCase();
+    })();
+    const shinyClass = SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
 
-    let setHtml = '';
-    if (setInfo) {
-      const bonusText = getSetBonusText(setInfo.set.bonuses);
-      const piecesEquipped = setInfo.equippedCount;
-      const piecesTotal = setInfo.set.itemIds.length;
-      setHtml = `
-        <div class="profile-item-set">
-          <div class="profile-item-set-name">${this.escapeHtml(setInfo.set.name)} (${piecesEquipped}/${piecesTotal})</div>
-          <div class="profile-item-set-bonus">${bonusText}</div>
-        </div>
-      `;
+    // Stat lines
+    const statLines: string[] = [];
+    if (effect && effect !== 'Material' && effect !== 'No bonus') {
+      statLines.push(`<div><span class="stat-label">Effect</span><span>${effect}</span></div>`);
+    }
+    if (def.equipSlot) {
+      statLines.push(`<div><span class="stat-label">Slot</span><span>${SLOT_LABELS[def.equipSlot] ?? def.equipSlot}</span></div>`);
+    } else {
+      statLines.push(`<div><span class="stat-label">Type</span><span>Material</span></div>`);
+    }
+    statLines.push(`<div><span class="stat-label">Rarity</span><span style="color:${color}">${def.rarity.charAt(0).toUpperCase() + def.rarity.slice(1)}</span></div>`);
+    if (def.value != null && def.value > 0) {
+      statLines.push(`<div><span class="stat-label">Value</span><span>${def.value}g</span></div>`);
+    }
+    if (def.classRestriction && def.classRestriction.length > 0) {
+      statLines.push(`<div><span class="stat-label">Class</span><span>${def.classRestriction.join(', ')}</span></div>`);
     }
 
-    const popup = document.createElement('div');
-    popup.className = 'profile-item-popup';
-    popup.innerHTML = `
-      <div class="profile-item-name" style="color:${color}">${this.escapeHtml(def.name)}</div>
-      <div class="profile-item-rarity" style="color:${color}">${def.rarity}</div>
-      ${effect ? `<div class="profile-item-effect">${effect}</div>` : ''}
-      ${setHtml}
+    // Set info
+    const setInfo = getSetInfoForItem(def.id, setDefs, equippedItemIds, equippedItemIds);
+    let setHtml = '';
+    if (setInfo) {
+      const itemDefs = this.gameClient.lastState?.itemDefinitions ?? {};
+      const piecesHtml = setInfo.set.itemIds.map(pieceId => {
+        const pieceDef = itemDefs[pieceId];
+        const pieceName = pieceDef?.name ?? pieceId;
+        const isEquipped = equippedItemIds.has(pieceId);
+        const cssClass = isEquipped ? 'equipped' : '';
+        const check = isEquipped ? '&#9745; ' : '&#9744; ';
+        return `<div class="item-popup-set-piece ${cssClass}">${check}${this.escapeHtml(pieceName)}</div>`;
+      }).join('');
+      const bonusText = getSetBonusText(setInfo.set.bonuses);
+      setHtml = `
+        <div class="item-popup-set-section">
+          <div class="item-popup-set-name">${this.escapeHtml(setInfo.set.name)} (${setInfo.equippedCount}/${setInfo.set.itemIds.length})</div>
+          <div class="item-popup-set-pieces">${piecesHtml}</div>
+          <div class="item-popup-set-bonus">Set bonus: ${bonusText}</div>
+        </div>`;
+    }
+
+    const overlay = document.createElement('div');
+    overlay.className = 'profile-item-popup-overlay item-popup-overlay';
+    overlay.style.zIndex = '10001';
+    overlay.innerHTML = `
+      <div class="item-popup">
+        <div class="item-popup-artwork${shinyClass}" style="background:${color}">
+          <img src="/item-artwork/${def.id}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
+          <span class="item-popup-initials">${initials}</span>
+        </div>
+        <div class="item-popup-name" style="color:${color}">${this.escapeHtml(def.name)}</div>
+        <div class="item-popup-stats">${statLines.join('')}</div>
+        ${setHtml}
+        <div class="item-popup-actions">
+          <button class="profile-item-close-btn">Close</button>
+        </div>
+      </div>
     `;
 
-    // Position near the anchor
-    const rect = anchor.getBoundingClientRect();
-    popup.style.position = 'fixed';
-    popup.style.left = `${rect.left + rect.width / 2}px`;
-    popup.style.top = `${rect.bottom + 4}px`;
-    popup.style.transform = 'translateX(-50%)';
-    popup.style.zIndex = '10001';
-    document.body.appendChild(popup);
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) overlay.remove();
+    });
+    overlay.querySelector('.profile-item-close-btn')!.addEventListener('click', () => overlay.remove());
 
-    // Dismiss on outside click
-    const dismiss = (e: MouseEvent) => {
-      if (!popup.contains(e.target as Node)) {
-        popup.remove();
-        document.removeEventListener('click', dismiss, true);
-      }
-    };
-    setTimeout(() => document.addEventListener('click', dismiss, true), 0);
+    document.body.appendChild(overlay);
   }
 }

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -1,7 +1,7 @@
 import type { GameClient } from '../network/GameClient';
 import type { ChatLocalStore } from '../network/ChatLocalStore';
 import type { ServerStateMessage, ClientSocialState, ChatMessage, ChatChannelType, PlayerListEntry, PlayerProfileMessage, TradeOfferItem, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
-import { MAX_PARTY_SIZE, CLASS_ICONS, UNKNOWN_CLASS_ICON, SERVER_ICON, getItemEffectText, DISPLAY_EQUIP_SLOTS, SKILL_SLOTS, getSkillById, getSetInfoForItem, getSetBonusText } from '@idle-party-rpg/shared';
+import { MAX_PARTY_SIZE, CLASS_ICONS, UNKNOWN_CLASS_ICON, SERVER_ICON, getItemEffectText, SKILL_SLOTS, getSkillById, getSetInfoForItem, getSetBonusText } from '@idle-party-rpg/shared';
 import type { Screen } from './ScreenManager';
 
 type SubTab = 'users' | 'guild' | 'party' | 'chat';
@@ -1900,21 +1900,53 @@ export class SocialScreen implements Screen {
       return name.substring(0, 2).toUpperCase();
     };
 
-    const equipHtml = DISPLAY_EQUIP_SLOTS.map(slot => {
+    const LEFT_SLOTS = ['head', 'shoulders', 'chest', 'gloves', 'foot'];
+    const RIGHT_SLOTS = ['back', 'necklace', 'bracers', 'ring', 'relic'];
+    const SHINY_RARITIES = new Set(['epic', 'legendary', 'heirloom']);
+
+    const renderProfileSlot = (slot: string) => {
       const itemId = profile.equipment[slot];
       const def = itemId ? profile.itemDefinitions[itemId] : null;
       const bgColor = def ? (RARITY_COLORS[def.rarity] ?? '#808080') : '#333';
       const initials = def ? getInitials(def.name) : '';
-      const label = SLOT_LABELS[slot] ?? slot;
-      const artworkUrl = (def as Record<string, unknown> | null)?.artworkUrl as string | undefined;
-      const imgHtml = artworkUrl
-        ? `<img src="${artworkUrl}" class="profile-equip-icon-img" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="profile-equip-icon-initials" style="display:none">${initials}</span>`
-        : `<span class="profile-equip-icon-initials">${initials}</span>`;
-      return `<div class="profile-equip-square" data-slot="${slot}" data-item-id="${itemId ?? ''}">
-        <div class="profile-equip-icon" style="background:${bgColor}">${imgHtml}</div>
-        <span class="profile-equip-label">${label}</span>
+      const shinyClass = def && SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
+      const slotAbbrev = !def ? ({'head':'H','shoulders':'S','chest':'C','gloves':'G','foot':'F','back':'K','necklace':'N','bracers':'B','ring':'R','relic':'L','mainhand':'M','offhand':'O'}[slot] ?? '') : '';
+
+      let inner = '';
+      if (def && itemId) {
+        inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
+          <span class="item-square-initials">${initials}</span>`;
+      } else {
+        inner = `<span class="item-square-initials" style="color:rgba(255,255,255,0.3)">${slotAbbrev}</span>`;
+      }
+
+      return `<div class="item-square profile-slot-square${shinyClass}" data-slot="${slot}" data-item-id="${itemId ?? ''}" title="${def ? def.name : (SLOT_LABELS[slot] ?? slot)}" style="background:${bgColor};border-color:${def ? 'rgba(180,180,180,0.25)' : 'rgba(255,255,255,0.08)'}">${inner}</div>`;
+    };
+
+    const leftSlotsHtml = LEFT_SLOTS.map(renderProfileSlot).join('');
+    const rightSlotsHtml = RIGHT_SLOTS.map(renderProfileSlot).join('');
+    const mainhandHtml = renderProfileSlot('mainhand');
+    const offhandHtml = renderProfileSlot('offhand');
+
+    const equipHtml = `
+      <div class="profile-equip-panel">
+        <div class="profile-equip-col profile-equip-left">${leftSlotsHtml}</div>
+        <div class="profile-equip-figure">
+          <div class="items-figure-body">
+            <div class="fig-head"></div>
+            <div class="fig-neck"></div>
+            <div class="fig-shoulders"><div class="fig-shoulder-l"></div><div class="fig-torso"></div><div class="fig-shoulder-r"></div></div>
+            <div class="fig-arms"><div class="fig-arm-l"></div><div class="fig-waist"><span class="fig-class-icon">${icon}</span></div><div class="fig-arm-r"></div></div>
+            <div class="fig-legs"><div class="fig-leg-l"></div><div class="fig-leg-gap"></div><div class="fig-leg-r"></div></div>
+            <div class="fig-feet"><div class="fig-foot-l"></div><div class="fig-foot-gap"></div><div class="fig-foot-r"></div></div>
+          </div>
+        </div>
+        <div class="profile-equip-col profile-equip-right">${rightSlotsHtml}</div>
+        <div class="profile-equip-bottom-left">${mainhandHtml}</div>
+        <div class="profile-equip-bottom-spacer"></div>
+        <div class="profile-equip-bottom-right">${offhandHtml}</div>
       </div>`;
-    }).join('');
+
 
     // Skills section
     const skillHtml = SKILL_SLOTS.map((slot, i) => {
@@ -1957,7 +1989,7 @@ export class SocialScreen implements Screen {
       <div class="profile-class">${profile.className}</div>
       <div class="profile-guild">${profile.guildName ? this.escapeHtml(profile.guildName) : 'No Guild'}</div>
       <div class="profile-section-label">Equipment</div>
-      <div class="profile-equipment" style="display:grid;grid-template-columns:repeat(6,1fr);gap:6px">${equipHtml}</div>
+      ${equipHtml}
       <div class="profile-section-label">Skills</div>
       <div class="profile-skills">${skillHtml}</div>
       <div class="profile-section-label">Party</div>
@@ -1974,7 +2006,7 @@ export class SocialScreen implements Screen {
       if (id) equippedItemIds.add(id);
     }
 
-    for (const el of modal.querySelectorAll('.profile-equip-square')) {
+    for (const el of modal.querySelectorAll('.profile-slot-square')) {
       el.addEventListener('click', () => {
         const itemId = el.getAttribute('data-item-id');
         if (!itemId) return;

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -1,8 +1,10 @@
 import type { GameClient } from '../network/GameClient';
 import type { ChatLocalStore } from '../network/ChatLocalStore';
 import type { ServerStateMessage, ClientSocialState, ChatMessage, ChatChannelType, PlayerListEntry, PlayerProfileMessage, TradeOfferItem, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
-import { MAX_PARTY_SIZE, CLASS_ICONS, UNKNOWN_CLASS_ICON, SERVER_ICON, getItemEffectText, SKILL_SLOTS, getSkillById, getSetInfoForItem, getSetBonusText } from '@idle-party-rpg/shared';
+import { MAX_PARTY_SIZE, CLASS_ICONS, UNKNOWN_CLASS_ICON, SERVER_ICON, getItemEffectText, SKILL_SLOTS, getSkillById } from '@idle-party-rpg/shared';
 import type { Screen } from './ScreenManager';
+import { RARITY_COLORS, renderItemIcon, renderEmptySlotIcon } from '../ui/ItemIcon';
+import { renderItemPopupContent } from '../ui/ItemPopup';
 
 type SubTab = 'users' | 'guild' | 'party' | 'chat';
 
@@ -1396,15 +1398,6 @@ export class SocialScreen implements Screen {
 
   // ── Trade Modal ───────────────────────────────────────────────
 
-  private static readonly RARITY_COLORS: Record<string, string> = {
-    janky: '#808080',
-    common: '#e8e8e8',
-    uncommon: '#66bb6a',
-    rare: '#4fc3f7',
-    epic: '#ee66e3',
-    legendary: '#9233df',
-    heirloom: '#e9bc18',
-  };
 
   /** Open the trade modal and propose a trade with the given user. */
   openTradeModal(targetUsername: string): void {
@@ -1561,7 +1554,7 @@ export class SocialScreen implements Screen {
       }
       const rows = offerItems.map(({ itemId, quantity }) => {
         const def = itemDefs[itemId];
-        const color = def ? (SocialScreen.RARITY_COLORS[def.rarity] ?? '#e8e8e8') : '#e8e8e8';
+        const color = def ? (RARITY_COLORS[def.rarity] ?? '#e8e8e8') : '#e8e8e8';
         const effect = def ? getItemEffectText(def) : '';
         return `<div class="trade-offer-row">
           <span class="trade-offer-name" style="color:${color}">${this.escapeHtml(def?.name ?? itemId)}</span>
@@ -1579,7 +1572,7 @@ export class SocialScreen implements Screen {
       }
       const rows = tradeableItems.map(id => {
         const def = itemDefs[id];
-        const color = def ? (SocialScreen.RARITY_COLORS[def.rarity] ?? '#e8e8e8') : '#e8e8e8';
+        const color = def ? (RARITY_COLORS[def.rarity] ?? '#e8e8e8') : '#e8e8e8';
         const invCount = (inventory[id] as number) ?? 0;
         const selQty = this.tradeSelectedItems.get(id) ?? 0;
         const effect = def ? getItemEffectText(def) : '';
@@ -1884,43 +1877,23 @@ export class SocialScreen implements Screen {
     const icon = CLASS_ICONS[profile.className] ?? UNKNOWN_CLASS_ICON;
 
     // Equipment section
-    const SLOT_LABELS: Record<string, string> = {
-      head: 'Head', shoulders: 'Shoulders', chest: 'Chest', bracers: 'Bracers',
-      gloves: 'Hands', mainhand: 'Main Hand', offhand: 'Offhand', foot: 'Feet',
-      ring: 'Ring', necklace: 'Necklace', back: 'Back', relic: 'Relic',
-    };
-    const RARITY_COLORS: Record<string, string> = {
-      janky: '#808080', common: '#e8e8e8', uncommon: '#66bb6a', rare: '#4fc3f7',
-      epic: '#ee66e3', legendary: '#9233df', heirloom: '#e9bc18',
-    };
-
-    const getInitials = (name: string): string => {
-      const words = name.split(/\s+/);
-      if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
-      return name.substring(0, 2).toUpperCase();
-    };
-
     const LEFT_SLOTS = ['head', 'shoulders', 'chest', 'gloves', 'foot'];
     const RIGHT_SLOTS = ['back', 'necklace', 'bracers', 'ring', 'relic'];
-    const SHINY_RARITIES = new Set(['epic', 'legendary', 'heirloom']);
 
     const renderProfileSlot = (slot: string) => {
       const itemId = profile.equipment[slot];
       const def = itemId ? profile.itemDefinitions[itemId] : null;
-      const bgColor = def ? (RARITY_COLORS[def.rarity] ?? '#808080') : '#333';
-      const initials = def ? getInitials(def.name) : '';
-      const shinyClass = def && SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
-      const slotAbbrev = !def ? ({'head':'H','shoulders':'S','chest':'C','gloves':'G','foot':'F','back':'K','necklace':'N','bracers':'B','ring':'R','relic':'L','mainhand':'M','offhand':'O'}[slot] ?? '') : '';
-
-      let inner = '';
+      const dataAttrs: Record<string, string> = { slot, 'item-id': itemId ?? '' };
       if (def && itemId) {
-        inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
-          <span class="item-square-initials">${initials}</span>`;
-      } else {
-        inner = `<span class="item-square-initials" style="color:rgba(255,255,255,0.3)">${slotAbbrev}</span>`;
+        return renderItemIcon(itemId, def, {
+          extraClass: 'profile-slot-square',
+          dataAttrs,
+        });
       }
-
-      return `<div class="item-square profile-slot-square${shinyClass}" data-slot="${slot}" data-item-id="${itemId ?? ''}" title="${def ? def.name : (SLOT_LABELS[slot] ?? slot)}" style="background:${bgColor};border-color:${def ? 'rgba(180,180,180,0.25)' : 'rgba(255,255,255,0.08)'}">${inner}</div>`;
+      return renderEmptySlotIcon(slot, {
+        extraClass: 'profile-slot-square',
+        dataAttrs,
+      });
     };
 
     const leftSlotsHtml = LEFT_SLOTS.map(renderProfileSlot).join('');
@@ -2028,84 +2001,19 @@ export class SocialScreen implements Screen {
     // Remove any existing popup
     document.querySelector('.profile-item-popup-overlay')?.remove();
 
-    const RARITY_COLORS: Record<string, string> = {
-      janky: '#808080', common: '#e8e8e8', uncommon: '#66bb6a', rare: '#4fc3f7',
-      epic: '#ee66e3', legendary: '#9233df', heirloom: '#e9bc18',
-    };
-    const SLOT_LABELS: Record<string, string> = {
-      head: 'Head', shoulders: 'Shoulders', chest: 'Chest', bracers: 'Bracers',
-      gloves: 'Hands', mainhand: 'Main Hand', offhand: 'Offhand', twohanded: 'Two-Handed',
-      foot: 'Feet', ring: 'Ring', necklace: 'Necklace', back: 'Back', relic: 'Relic',
-    };
-    const SHINY_RARITIES = new Set(['epic', 'legendary', 'heirloom']);
-
-    const color = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
-    const effect = getItemEffectText(def);
-    const initials = (() => {
-      const words = def.name.split(/\s+/).filter(Boolean);
-      if (words.length === 0) return '?';
-      if (words.length === 1) return words[0].substring(0, 2).toUpperCase();
-      return (words[0][0] + words[1][0]).toUpperCase();
-    })();
-    const shinyClass = SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
-
-    // Stat lines
-    const statLines: string[] = [];
-    if (effect && effect !== 'Material' && effect !== 'No bonus') {
-      statLines.push(`<div><span class="stat-label">Effect</span><span>${effect}</span></div>`);
-    }
-    if (def.equipSlot) {
-      statLines.push(`<div><span class="stat-label">Slot</span><span>${SLOT_LABELS[def.equipSlot] ?? def.equipSlot}</span></div>`);
-    } else {
-      statLines.push(`<div><span class="stat-label">Type</span><span>Material</span></div>`);
-    }
-    statLines.push(`<div><span class="stat-label">Rarity</span><span style="color:${color}">${def.rarity.charAt(0).toUpperCase() + def.rarity.slice(1)}</span></div>`);
-    if (def.value != null && def.value > 0) {
-      statLines.push(`<div><span class="stat-label">Value</span><span>${def.value}g</span></div>`);
-    }
-    if (def.classRestriction && def.classRestriction.length > 0) {
-      statLines.push(`<div><span class="stat-label">Class</span><span>${def.classRestriction.join(', ')}</span></div>`);
-    }
-
-    // Set info
-    const setInfo = getSetInfoForItem(def.id, setDefs, equippedItemIds, equippedItemIds);
-    let setHtml = '';
-    if (setInfo) {
-      const itemDefs = this.gameClient.lastState?.itemDefinitions ?? {};
-      const piecesHtml = setInfo.set.itemIds.map(pieceId => {
-        const pieceDef = itemDefs[pieceId];
-        const pieceName = pieceDef?.name ?? pieceId;
-        const isEquipped = equippedItemIds.has(pieceId);
-        const cssClass = isEquipped ? 'equipped' : '';
-        const check = isEquipped ? '&#9745; ' : '&#9744; ';
-        return `<div class="item-popup-set-piece ${cssClass}">${check}${this.escapeHtml(pieceName)}</div>`;
-      }).join('');
-      const bonusText = getSetBonusText(setInfo.set.bonuses);
-      setHtml = `
-        <div class="item-popup-set-section">
-          <div class="item-popup-set-name">${this.escapeHtml(setInfo.set.name)} (${setInfo.equippedCount}/${setInfo.set.itemIds.length})</div>
-          <div class="item-popup-set-pieces">${piecesHtml}</div>
-          <div class="item-popup-set-bonus">Set bonus: ${bonusText}</div>
-        </div>`;
-    }
+    const itemDefs = this.gameClient.lastState?.itemDefinitions ?? {};
+    const popupContent = renderItemPopupContent(def, {
+      itemDefs,
+      setDefs,
+      ownedItemIds: equippedItemIds,
+      equippedItemIds,
+      actionsHtml: '<button class="profile-item-close-btn">Close</button>',
+    });
 
     const overlay = document.createElement('div');
     overlay.className = 'profile-item-popup-overlay item-popup-overlay';
     overlay.style.zIndex = '10001';
-    overlay.innerHTML = `
-      <div class="item-popup">
-        <div class="item-popup-artwork${shinyClass}" style="background:${color}">
-          <img src="/item-artwork/${def.id}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
-          <span class="item-popup-initials">${initials}</span>
-        </div>
-        <div class="item-popup-name" style="color:${color}">${this.escapeHtml(def.name)}</div>
-        <div class="item-popup-stats">${statLines.join('')}</div>
-        ${setHtml}
-        <div class="item-popup-actions">
-          <button class="profile-item-close-btn">Close</button>
-        </div>
-      </div>
-    `;
+    overlay.innerHTML = `<div class="item-popup">${popupContent}</div>`;
 
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) overlay.remove();

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -1201,9 +1201,10 @@ html, body {
 
 .items-equip-panel {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  gap: 4px;
+  grid-template-columns: auto 1fr auto;
+  gap: 6px;
   align-items: center;
+  justify-items: center;
 }
 
 .items-equip-col {
@@ -1298,7 +1299,7 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 8px;
+  padding: 8px 16px;
 }
 
 .items-figure-body {
@@ -1306,6 +1307,8 @@ html, body {
   flex-direction: column;
   align-items: center;
   opacity: 0.35;
+  transform: scale(1.5);
+  transform-origin: center center;
 }
 
 .fig-head {
@@ -1398,6 +1401,15 @@ html, body {
 
 .fig-foot-gap {
   width: 0px;
+}
+
+@media (min-width: 768px) {
+  .items-figure-body {
+    transform: scale(1.8);
+  }
+  .items-equip-figure {
+    padding: 12px 24px;
+  }
 }
 
 .items-inventory {
@@ -4376,23 +4388,48 @@ html, body {
   font-size: 11px;
 }
 
-/* Equipment grid for profile view */
-.profile-equip-grid {
+/* Equipment panel for profile view — mirrors items screen layout */
+.profile-equip-panel {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 4px;
+  grid-template-columns: auto 1fr auto;
+  gap: 6px;
+  align-items: center;
+  justify-items: center;
   margin: 8px 0;
 }
-.profile-equip-slot {
-  text-align: center;
+.profile-equip-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
-.profile-equip-slot .item-square {
-  width: 100%;
-  margin-bottom: 2px;
+.profile-equip-left {
+  align-items: flex-end;
 }
-.profile-equip-slot-label {
-  font-size: 8px;
-  color: #888;
+.profile-equip-right {
+  align-items: flex-start;
+}
+.profile-equip-figure {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+}
+.profile-equip-figure .items-figure-body {
+  transform: scale(1.3);
+}
+.profile-equip-bottom-left {
+  justify-self: end;
+}
+.profile-equip-bottom-right {
+  justify-self: start;
+}
+.profile-equip-bottom-spacer {
+  /* empty cell matching the figure column */
+}
+.profile-slot-square {
+  width: 36px;
+  height: 36px;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3);
 }
 
 /* Shop popup */

--- a/client/src/ui/ItemIcon.ts
+++ b/client/src/ui/ItemIcon.ts
@@ -1,0 +1,109 @@
+import type { ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
+
+export const RARITY_COLORS: Record<string, string> = {
+  janky: '#808080',
+  common: '#e8e8e8',
+  uncommon: '#66bb6a',
+  rare: '#4fc3f7',
+  epic: '#ee66e3',
+  legendary: '#9233df',
+  heirloom: '#e9bc18',
+};
+
+export const SLOT_ICONS: Record<string, string> = {
+  head: 'H', shoulders: 'S', chest: 'C', bracers: 'B', gloves: 'G',
+  mainhand: 'M', offhand: 'O', twohanded: '2H', foot: 'F',
+  ring: 'R', necklace: 'N', back: 'K', relic: 'L',
+};
+
+export const SLOT_LABELS: Record<string, string> = {
+  head: 'Head', shoulders: 'Shoulders', chest: 'Chest', bracers: 'Bracers',
+  gloves: 'Hands', mainhand: 'Main Hand', offhand: 'Offhand', twohanded: 'Two-Handed',
+  foot: 'Feet', ring: 'Ring', necklace: 'Necklace', back: 'Back', relic: 'Relic',
+};
+
+export const SHINY_RARITIES = new Set(['epic', 'legendary', 'heirloom']);
+
+export const RARITY_ORDER: Record<string, number> = {
+  heirloom: 0, legendary: 1, epic: 2, rare: 3, uncommon: 4, common: 5, janky: 6,
+};
+
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+export function getItemInitials(name: string): string {
+  const words = name.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '?';
+  if (words.length === 1) return words[0].substring(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+/** Check if an item belongs to any set; returns the set ID or null. */
+export function getItemSetId(itemId: string, setDefs: Record<string, SetDefinition>): string | null {
+  for (const set of Object.values(setDefs)) {
+    if (set.itemIds.includes(itemId)) return set.id;
+  }
+  return null;
+}
+
+export interface ItemIconOptions {
+  qty?: number;
+  showSlotIcon?: boolean;
+  showSetIndicator?: boolean;
+  setDefs?: Record<string, SetDefinition>;
+  /** Extra CSS classes */
+  extraClass?: string;
+  /** data attributes as key-value pairs */
+  dataAttrs?: Record<string, string>;
+}
+
+/**
+ * Render a square item icon as HTML string.
+ * Options control what overlays appear (qty badge, set indicator, slot icon).
+ */
+export function renderItemIcon(itemId: string, def: ItemDefinition, options?: ItemIconOptions): string {
+  const rarity = def.rarity ?? 'common';
+  const bgColor = RARITY_COLORS[rarity] ?? '#e8e8e8';
+  const shinyClass = SHINY_RARITIES.has(rarity) ? ` item-rarity-${rarity}` : '';
+  const initials = getItemInitials(def.name);
+  const extraClass = options?.extraClass ? ` ${options.extraClass}` : '';
+
+  const dataStr = options?.dataAttrs
+    ? Object.entries(options.dataAttrs).map(([k, v]) => ` data-${k}="${escapeHtml(v)}"`).join('')
+    : '';
+
+  let inner = `<img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
+    <span class="item-square-initials">${initials}</span>`;
+
+  if (options?.showSetIndicator && options.setDefs && getItemSetId(itemId, options.setDefs)) {
+    inner += `<span class="item-square-set">S</span>`;
+  }
+
+  if (options?.qty != null && options.qty > 1) {
+    inner += `<span class="item-square-qty">${options.qty}</span>`;
+  }
+
+  if (options?.showSlotIcon && def.equipSlot) {
+    const slotIcon = SLOT_ICONS[def.equipSlot] ?? '';
+    if (slotIcon) {
+      inner += `<span class="item-square-slot-icon">${slotIcon}</span>`;
+    }
+  }
+
+  return `<div class="item-square${shinyClass}${extraClass}" title="${escapeHtml(def.name)}" style="background:${bgColor}"${dataStr}>${inner}</div>`;
+}
+
+/**
+ * Render an empty equipment slot icon.
+ */
+export function renderEmptySlotIcon(slot: string, options?: { extraClass?: string; dataAttrs?: Record<string, string> }): string {
+  const extraClass = options?.extraClass ? ` ${options.extraClass}` : '';
+  const dataStr = options?.dataAttrs
+    ? Object.entries(options.dataAttrs).map(([k, v]) => ` data-${k}="${escapeHtml(v)}"`).join('')
+    : '';
+  const slotAbbrev = SLOT_ICONS[slot] ?? '';
+  const label = SLOT_LABELS[slot] ?? slot;
+
+  return `<div class="item-square${extraClass}" title="${escapeHtml(label)}" style="background:#333333"${dataStr}><span class="item-square-initials" style="color:rgba(255,255,255,0.3)">${slotAbbrev}</span></div>`;
+}

--- a/client/src/ui/ItemPopup.ts
+++ b/client/src/ui/ItemPopup.ts
@@ -1,0 +1,101 @@
+import type { ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
+import { getItemEffectText, getSetInfoForItem, getSetBonusText } from '@idle-party-rpg/shared';
+import { RARITY_COLORS, SLOT_LABELS, SHINY_RARITIES, getItemInitials, escapeHtml } from './ItemIcon';
+
+export interface ItemPopupOptions {
+  /** Item definitions for looking up set piece names */
+  itemDefs?: Record<string, ItemDefinition>;
+  setDefs?: Record<string, SetDefinition>;
+  /** Set of item IDs the player owns (inventory + equipped) */
+  ownedItemIds?: Set<string>;
+  /** Set of item IDs currently equipped */
+  equippedItemIds?: Set<string>;
+  /** Action buttons HTML (empty string for read-only view) */
+  actionsHtml?: string;
+}
+
+/**
+ * Create the inner HTML for an item popup (without the overlay wrapper).
+ * Useful for embedding in other modals.
+ */
+export function renderItemPopupContent(def: ItemDefinition, options?: ItemPopupOptions): string {
+  const color = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
+  const initials = getItemInitials(def.name);
+  const shinyClass = SHINY_RARITIES.has(def.rarity) ? ` item-rarity-${def.rarity}` : '';
+
+  // Build stat lines
+  const statLines: string[] = [];
+  const effect = getItemEffectText(def);
+  if (effect && effect !== 'Material' && effect !== 'No bonus') {
+    statLines.push(`<div><span class="stat-label">Effect</span><span>${effect}</span></div>`);
+  }
+  if (def.equipSlot) {
+    statLines.push(`<div><span class="stat-label">Slot</span><span>${SLOT_LABELS[def.equipSlot] ?? def.equipSlot}</span></div>`);
+  } else {
+    statLines.push(`<div><span class="stat-label">Type</span><span>Material</span></div>`);
+  }
+  statLines.push(`<div><span class="stat-label">Rarity</span><span style="color:${color}">${def.rarity.charAt(0).toUpperCase() + def.rarity.slice(1)}</span></div>`);
+  if (def.value != null && def.value > 0) {
+    statLines.push(`<div><span class="stat-label">Value</span><span>${def.value}g</span></div>`);
+  }
+  if (def.classRestriction && def.classRestriction.length > 0) {
+    statLines.push(`<div><span class="stat-label">Class</span><span>${def.classRestriction.join(', ')}</span></div>`);
+  }
+
+  // Set info section
+  const setDefs = options?.setDefs ?? {};
+  const ownedItemIds = options?.ownedItemIds;
+  const equippedItemIds = options?.equippedItemIds;
+  const itemDefs = options?.itemDefs ?? {};
+
+  const setInfo = getSetInfoForItem(def.id, setDefs, ownedItemIds, equippedItemIds);
+  let setHtml = '';
+  if (setInfo) {
+    const piecesHtml = setInfo.set.itemIds.map(pieceId => {
+      const pieceDef = itemDefs[pieceId];
+      const pieceName = pieceDef?.name ?? pieceId;
+      const isEquipped = equippedItemIds?.has(pieceId) ?? false;
+      const isOwned = ownedItemIds?.has(pieceId) ?? false;
+      const cssClass = isEquipped ? 'equipped' : isOwned ? 'owned' : '';
+      const check = isOwned || isEquipped ? (isEquipped ? '&#9745; ' : '&#9744; ') : '&#9744; ';
+      return `<div class="item-popup-set-piece ${cssClass}">${check}${escapeHtml(pieceName)}</div>`;
+    }).join('');
+    const bonusText = getSetBonusText(setInfo.set.bonuses);
+    setHtml = `
+      <div class="item-popup-set-section">
+        <div class="item-popup-set-name">${escapeHtml(setInfo.set.name)} (${setInfo.equippedCount}/${setInfo.set.itemIds.length})</div>
+        <div class="item-popup-set-pieces">${piecesHtml}</div>
+        <div class="item-popup-set-bonus">Set bonus: ${bonusText}</div>
+      </div>`;
+  }
+
+  const actionsHtml = options?.actionsHtml ?? '';
+
+  return `
+    <div class="item-popup-artwork${shinyClass}" style="background:${color}">
+      <img src="/item-artwork/${def.id}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" alt="">
+      <span class="item-popup-initials">${initials}</span>
+    </div>
+    <div class="item-popup-name" style="color:${color}">${escapeHtml(def.name)}</div>
+    <div class="item-popup-stats">${statLines.join('')}</div>
+    ${setHtml}
+    ${actionsHtml ? `<div class="item-popup-actions">${actionsHtml}</div>` : ''}
+  `;
+}
+
+/**
+ * Show an item popup modal overlay. Returns the overlay element.
+ * Caller is responsible for wiring action button click handlers.
+ */
+export function showItemPopup(def: ItemDefinition, options?: ItemPopupOptions): HTMLElement {
+  const overlay = document.createElement('div');
+  overlay.className = 'item-popup-overlay';
+  overlay.innerHTML = `<div class="item-popup">${renderItemPopupContent(def, options)}</div>`;
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.remove();
+  });
+
+  document.body.appendChild(overlay);
+  return overlay;
+}

--- a/client/src/ui/ShopPopup.ts
+++ b/client/src/ui/ShopPopup.ts
@@ -1,19 +1,8 @@
 import type { GameClient } from '../network/GameClient';
 import type { ServerStateMessage } from '@idle-party-rpg/shared';
 import type { ShopDefinition, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
-import { getItemEffectText, getSetInfoForItem, getSetBonusText } from '@idle-party-rpg/shared';
-
-const RARITY_COLORS: Record<string, string> = {
-  janky: '#808080',
-  common: '#e8e8e8',
-  uncommon: '#66bb6a',
-  rare: '#4fc3f7',
-  epic: '#ee66e3',
-  legendary: '#9233df',
-  heirloom: '#e9bc18',
-};
-
-const RARITY_ORDER = ['janky', 'common', 'uncommon', 'rare', 'epic', 'legendary', 'heirloom'];
+import { renderItemIcon, escapeHtml } from './ItemIcon';
+import { renderItemPopupContent } from './ItemPopup';
 
 export class ShopPopup {
   private overlay: HTMLElement;
@@ -62,7 +51,7 @@ export class ShopPopup {
     this.overlay.innerHTML = `
       <div class="shop-popup">
         <div class="shop-header">
-          <span class="shop-title">${this.escapeHtml(shop.name)}</span>
+          <span class="shop-title">${escapeHtml(shop.name)}</span>
           <span class="shop-gold">${char.gold} gold</span>
         </div>
         <div class="shop-toggle">
@@ -105,17 +94,21 @@ export class ShopPopup {
   private renderBuyItems(shop: ShopDefinition, itemDefs: Record<string, ItemDefinition>, _setDefs: Record<string, SetDefinition>): string {
     return shop.inventory.map(si => {
       const def = itemDefs[si.itemId];
-      const name = def?.name ?? si.itemId;
-      const rarity = def?.rarity ?? 'common';
-      const color = RARITY_COLORS[rarity] ?? '#e8e8e8';
-      const initials = name.split(' ').map(w => w[0]).join('').slice(0, 2);
-      const rarityClass = RARITY_ORDER.indexOf(rarity) >= 4 ? ` item-rarity-${rarity}` : '';
-
-      return `<div class="item-square shop-item-square${rarityClass}" data-item-id="${si.itemId}" data-price="${si.price}" style="background:${color}40;" title="${this.escapeHtml(name)}">
-        <img class="item-square-img" src="/item-artwork/${si.itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'">
-        <span class="item-square-initials">${initials}</span>
-        <span class="shop-item-price">${si.price}g</span>
-      </div>`;
+      if (!def) {
+        const name = si.itemId;
+        return `<div class="item-square shop-item-square" data-item-id="${si.itemId}" data-price="${si.price}" style="background:#e8e8e840;" title="${escapeHtml(name)}">
+          <span class="item-square-initials">${name.split(' ').map(w => w[0]).join('').slice(0, 2)}</span>
+          <span class="shop-item-price">${si.price}g</span>
+        </div>`;
+      }
+      // renderItemIcon produces the outer div; we need to inject shop-specific data attrs and the price overlay.
+      // Use renderItemIcon with extra class and data attrs, then append the price span.
+      const html = renderItemIcon(si.itemId, def, {
+        extraClass: 'shop-item-square',
+        dataAttrs: { 'item-id': si.itemId, price: String(si.price) },
+      });
+      // Inject price badge before closing </div>
+      return html.replace(/<\/div>$/, `<span class="shop-item-price">${si.price}g</span></div>`);
     }).join('');
   }
 
@@ -135,19 +128,20 @@ export class ShopPopup {
 
     return entries.map(([itemId, qty]) => {
       const def = itemDefs[itemId];
-      const name = def?.name ?? itemId;
-      const rarity = def?.rarity ?? 'common';
-      const color = RARITY_COLORS[rarity] ?? '#e8e8e8';
-      const initials = name.split(' ').map(w => w[0]).join('').slice(0, 2);
-      const rarityClass = RARITY_ORDER.indexOf(rarity) >= 4 ? ` item-rarity-${rarity}` : '';
-      const value = def?.value ?? 1;
-
-      return `<div class="item-square shop-item-square${rarityClass}" data-item-id="${itemId}" data-qty="${qty}" style="background:${color}40;" title="${this.escapeHtml(name)}">
-        <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'">
-        <span class="item-square-initials">${initials}</span>
-        ${qty > 1 ? `<span class="item-square-qty">x${qty}</span>` : ''}
-        <span class="shop-item-price">${value}g</span>
-      </div>`;
+      if (!def) {
+        return `<div class="item-square shop-item-square" data-item-id="${itemId}" data-qty="${qty}" style="background:#e8e8e840;" title="${escapeHtml(itemId)}">
+          <span class="item-square-initials">${itemId.split(' ').map(w => w[0]).join('').slice(0, 2)}</span>
+          <span class="shop-item-price">1g</span>
+        </div>`;
+      }
+      const value = def.value ?? 1;
+      const html = renderItemIcon(itemId, def, {
+        qty,
+        extraClass: 'shop-item-square',
+        dataAttrs: { 'item-id': itemId, qty: String(qty) },
+      });
+      // Inject price badge before closing </div>
+      return html.replace(/<\/div>$/, `<span class="shop-item-price">${value}g</span></div>`);
     }).join('');
   }
 
@@ -159,39 +153,18 @@ export class ShopPopup {
   ): void {
     const def = itemDefs[itemId];
     if (!def) return;
-    const color = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
-    const initials = def.name.split(' ').map(w => w[0]).join('').slice(0, 2);
-    const effects = getItemEffectText(def);
-    const setInfo = getSetInfoForItem(itemId, setDefs);
 
-    const setHtml = setInfo ? `
-      <div class="item-popup-set">
-        <div class="item-popup-set-name">${this.escapeHtml(setInfo.set.name)} (${setInfo.equippedCount}/${setInfo.set.itemIds.length})</div>
-        <div class="item-popup-set-bonus">${getSetBonusText(setInfo.set.bonuses)}</div>
-      </div>
-    ` : '';
-
-    this.overlay.innerHTML = `
-      <div class="item-popup">
-        <div class="item-popup-artwork" style="background:${color}40;">
-          <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" style="width:64px;height:64px;">
-          <span class="item-square-initials" style="font-size:28px;">${initials}</span>
-        </div>
-        <div class="item-popup-name" style="color:${color}">${this.escapeHtml(def.name)}</div>
-        <div class="item-popup-stats">
-          <div>${effects}</div>
-          <div>Value: ${def.value ?? 1} gold</div>
-          ${def.equipSlot ? `<div>Slot: ${def.equipSlot}</div>` : '<div>Material</div>'}
-          ${def.classRestriction?.length ? `<div>Class: ${def.classRestriction.join(', ')}</div>` : ''}
-        </div>
-        ${setHtml}
+    const popupContent = renderItemPopupContent(def, {
+      itemDefs,
+      setDefs,
+      actionsHtml: `
         <div style="margin-top:12px;font-size:14px;color:#ffd700;">Price: ${price} gold</div>
-        <div class="item-popup-actions">
-          <button class="item-popup-btn item-popup-btn-primary shop-buy-confirm">Buy</button>
-          <button class="item-popup-btn item-popup-btn-secondary shop-detail-back">Back</button>
-        </div>
-      </div>
-    `;
+        <button class="item-popup-btn item-popup-btn-primary shop-buy-confirm">Buy</button>
+        <button class="item-popup-btn item-popup-btn-secondary shop-detail-back">Back</button>
+      `,
+    });
+
+    this.overlay.innerHTML = `<div class="item-popup">${popupContent}</div>`;
 
     this.overlay.querySelector('.shop-buy-confirm')?.addEventListener('click', () => {
       this.gameClient.sendShopBuy(itemId);
@@ -210,18 +183,7 @@ export class ShopPopup {
   ): void {
     const def = itemDefs[itemId];
     if (!def) return;
-    const color = RARITY_COLORS[def.rarity] ?? '#e8e8e8';
-    const initials = def.name.split(' ').map(w => w[0]).join('').slice(0, 2);
-    const effects = getItemEffectText(def);
     const value = def.value ?? 1;
-    const setInfo = getSetInfoForItem(itemId, setDefs);
-
-    const setHtml = setInfo ? `
-      <div class="item-popup-set">
-        <div class="item-popup-set-name">${this.escapeHtml(setInfo.set.name)} (${setInfo.equippedCount}/${setInfo.set.itemIds.length})</div>
-        <div class="item-popup-set-bonus">${getSetBonusText(setInfo.set.bonuses)}</div>
-      </div>
-    ` : '';
 
     let qty = 1;
 
@@ -232,19 +194,10 @@ export class ShopPopup {
       if (totalEl) totalEl.textContent = `Total: ${qty * value} gold`;
     };
 
-    this.overlay.innerHTML = `
-      <div class="item-popup">
-        <div class="item-popup-artwork" style="background:${color}40;">
-          <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" style="width:64px;height:64px;">
-          <span class="item-square-initials" style="font-size:28px;">${initials}</span>
-        </div>
-        <div class="item-popup-name" style="color:${color}">${this.escapeHtml(def.name)}</div>
-        <div class="item-popup-stats">
-          <div>${effects}</div>
-          <div>Value: ${value} gold each</div>
-          ${def.equipSlot ? `<div>Slot: ${def.equipSlot}</div>` : '<div>Material</div>'}
-        </div>
-        ${setHtml}
+    const popupContent = renderItemPopupContent(def, {
+      itemDefs,
+      setDefs,
+      actionsHtml: `
         <div class="shop-sell-controls">
           <button class="shop-qty-btn shop-qty-minus">-</button>
           <span class="shop-qty-value">1</span>
@@ -252,12 +205,12 @@ export class ShopPopup {
           <button class="shop-qty-btn shop-qty-all">All</button>
         </div>
         <div class="shop-sell-total" style="color:#ffd700;margin-top:4px;">Total: ${value} gold</div>
-        <div class="item-popup-actions">
-          <button class="item-popup-btn item-popup-btn-primary shop-sell-confirm">Sell</button>
-          <button class="item-popup-btn item-popup-btn-secondary shop-detail-back">Back</button>
-        </div>
-      </div>
-    `;
+        <button class="item-popup-btn item-popup-btn-primary shop-sell-confirm">Sell</button>
+        <button class="item-popup-btn item-popup-btn-secondary shop-detail-back">Back</button>
+      `,
+    });
+
+    this.overlay.innerHTML = `<div class="item-popup">${popupContent}</div>`;
 
     this.overlay.querySelector('.shop-qty-minus')?.addEventListener('click', () => {
       qty = Math.max(1, qty - 1);
@@ -280,7 +233,4 @@ export class ShopPopup {
     });
   }
 
-  private escapeHtml(s: string): string {
-    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-  }
 }

--- a/client/src/ui/ShopPopup.ts
+++ b/client/src/ui/ShopPopup.ts
@@ -112,7 +112,7 @@ export class ShopPopup {
       const rarityClass = RARITY_ORDER.indexOf(rarity) >= 4 ? ` item-rarity-${rarity}` : '';
 
       return `<div class="item-square shop-item-square${rarityClass}" data-item-id="${si.itemId}" data-price="${si.price}" style="background:${color}40;" title="${this.escapeHtml(name)}">
-        <img class="item-square-img" src="/item-artwork/${si.itemId}.png" onerror="this.style.display='none'">
+        <img class="item-square-img" src="/item-artwork/${si.itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'">
         <span class="item-square-initials">${initials}</span>
         <span class="shop-item-price">${si.price}g</span>
       </div>`;
@@ -143,7 +143,7 @@ export class ShopPopup {
       const value = def?.value ?? 1;
 
       return `<div class="item-square shop-item-square${rarityClass}" data-item-id="${itemId}" data-qty="${qty}" style="background:${color}40;" title="${this.escapeHtml(name)}">
-        <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'">
+        <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'">
         <span class="item-square-initials">${initials}</span>
         ${qty > 1 ? `<span class="item-square-qty">x${qty}</span>` : ''}
         <span class="shop-item-price">${value}g</span>
@@ -174,7 +174,7 @@ export class ShopPopup {
     this.overlay.innerHTML = `
       <div class="item-popup">
         <div class="item-popup-artwork" style="background:${color}40;">
-          <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" style="width:64px;height:64px;">
+          <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" style="width:64px;height:64px;">
           <span class="item-square-initials" style="font-size:28px;">${initials}</span>
         </div>
         <div class="item-popup-name" style="color:${color}">${this.escapeHtml(def.name)}</div>
@@ -235,7 +235,7 @@ export class ShopPopup {
     this.overlay.innerHTML = `
       <div class="item-popup">
         <div class="item-popup-artwork" style="background:${color}40;">
-          <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" style="width:64px;height:64px;">
+          <img class="item-square-img" src="/item-artwork/${itemId}.png" onerror="this.style.display='none'" onload="this.nextElementSibling.style.display='none'" style="width:64px;height:64px;">
           <span class="item-square-initials" style="font-size:28px;">${initials}</span>
         </div>
         <div class="item-popup-name" style="color:${color}">${this.escapeHtml(def.name)}</div>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true,
       },
+      '/item-artwork': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
     },
   },
   resolve: {

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -123,7 +123,7 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
   /** Add or update a world tile. Supports ?versionId= for draft editing. */
   router.put('/world/tile', async (req, res) => {
     const versionId = req.query.versionId as string | undefined;
-    const { col, row, type, zone, name, encounterTable } = req.body;
+    const { col, row, type, zone, name, encounterTable, shopId } = req.body;
     if (col == null || row == null || !type || !zone || !name) {
       res.status(400).json({ error: 'Missing required fields: col, row, type, zone, name' });
       return;
@@ -151,16 +151,16 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
       const idx = snapshot.world.tiles.findIndex(t => t.col === col && t.row === row);
       if (idx >= 0) {
         // Preserve existing GUID on update
-        snapshot.world.tiles[idx] = { id: snapshot.world.tiles[idx].id, col, row, type, zone, name, encounterTable: tileEncounterTable };
+        snapshot.world.tiles[idx] = { id: snapshot.world.tiles[idx].id, col, row, type, zone, name, encounterTable: tileEncounterTable, shopId: shopId || undefined };
       } else {
         // New tile — generate a GUID
-        snapshot.world.tiles.push({ id: crypto.randomUUID(), col, row, type, zone, name, encounterTable: tileEncounterTable });
+        snapshot.world.tiles.push({ id: crypto.randomUUID(), col, row, type, zone, name, encounterTable: tileEncounterTable, shopId: shopId || undefined });
       }
       await versions.saveSnapshot(versionId, snapshot);
       res.json({ success: true, world: snapshot.world });
     } else {
       const content = getContentStore();
-      await content.addOrUpdateTile({ id: '', col, row, type, zone, name, encounterTable: tileEncounterTable });
+      await content.addOrUpdateTile({ id: '', col, row, type, zone, name, encounterTable: tileEncounterTable, shopId: shopId || undefined });
       const relocated = rebuildGrid();
       res.json({ success: true, world: content.getWorld(), relocated });
     }

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -22,7 +22,7 @@ export type PartyState = 'idle' | 'moving' | 'in_battle';
 export const RESULT_PAUSE = 600;      // ms to show victory/defeat before movement
 export const MOVE_DURATION = 400;     // ms for tile movement (client animation)
 export const RUN_AVAILABLE_ROUNDS = 5; // rounds before "Run" becomes available
-export const GAME_VERSION = '2026.04.03.1'; // Keep in sync with PATCH_NOTES in client
+export const GAME_VERSION = '2026.04.03.2'; // Keep in sync with PATCH_NOTES in client
 
 // --- Protocol types (server → client, client → server) ---
 


### PR DESCRIPTION
## Summary
- **Item UI polish**: Artwork now replaces initials on load; all item squares have gray frames with inner shadow; epic/legendary/heirloom get rarity-colored animated glowing borders; silhouette enlarged 1.5x (1.8x desktop) with equipment slots positioned as sides of an invisible square
- **Player profile equipment**: Now uses the same silhouette + slot layout as the items screen; clicking an item shows the full item detail popup (read-only, no action buttons)
- **Bug fix**: Shop assignment on tiles was not saving — `shopId` was missing from the tile PUT endpoint destructuring
- **Code quality**: Extracted `ItemIcon.ts` and `ItemPopup.ts` shared modules to eliminate duplicated item rendering across ItemsScreen, SocialScreen, and ShopPopup
- **Admin routing**: Tab changes update the URL (`/admin/sets`, `/admin/map`, etc.); browser back/forward works; selected version persists across page refresh via sessionStorage
- **Dev proxy**: Added `/item-artwork` Vite proxy so artwork loads in dev mode

## Test plan
- [x] `npm run build` passes (shared, client, server)
- [x] `npm run test` — all 100 tests pass
- [ ] Manual: verify item artwork replaces initials when present
- [ ] Manual: verify animated borders on epic/legendary/heirloom items
- [ ] Manual: verify shop saves on tiles in admin
- [ ] Manual: verify admin URL routing persists across refresh
- [ ] Manual: verify player profile shows same equipment layout as items screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)