### PR TITLE
Equipment UI: emoji slot icons, centered square panel, empty slot tooltips

### DIFF
--- a/client/src/screens/ItemsScreen.ts
+++ b/client/src/screens/ItemsScreen.ts
@@ -3,7 +3,7 @@ import type { ServerStateMessage, ServerEquipBlockedMessage } from '@idle-party-
 import { CLASS_ICONS, UNKNOWN_CLASS_ICON } from '@idle-party-rpg/shared';
 import type { EquipSlot, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
 import type { Screen } from './ScreenManager';
-import { RARITY_ORDER, renderItemIcon, renderEmptySlotIcon } from '../ui/ItemIcon';
+import { RARITY_ORDER, SLOT_LABELS, renderItemIcon, renderEmptySlotIcon } from '../ui/ItemIcon';
 import { renderItemPopupContent } from '../ui/ItemPopup';
 
 /** Left column slots (top to bottom). */
@@ -437,6 +437,9 @@ export class ItemsScreen implements Screen {
       const itemId = slotEl.getAttribute('data-item-id');
       if (slot && itemId) {
         this.showItemPopup(itemId, 'equipped', slot);
+      } else if (slot) {
+        // Empty slot — show tooltip with slot name
+        this.showSlotTooltip(slotEl, slot);
       }
     });
 
@@ -721,6 +724,25 @@ export class ItemsScreen implements Screen {
         this.hideModal();
       }
     );
+  }
+
+  private showSlotTooltip(anchor: HTMLElement, slot: EquipSlot): void {
+    // Remove any existing tooltip
+    document.querySelector('.items-slot-tooltip')?.remove();
+
+    const label = SLOT_LABELS[slot] ?? slot;
+    const tooltip = document.createElement('div');
+    tooltip.className = 'items-slot-tooltip';
+    tooltip.textContent = label;
+    tooltip.style.cssText = 'position:fixed;background:#222;color:#e8e8e8;padding:4px 10px;border-radius:4px;font-size:11px;z-index:1000;pointer-events:none;border:1px solid #555;white-space:nowrap;';
+
+    document.body.appendChild(tooltip);
+
+    const rect = anchor.getBoundingClientRect();
+    tooltip.style.left = `${rect.left + rect.width / 2 - tooltip.offsetWidth / 2}px`;
+    tooltip.style.top = `${rect.bottom + 4}px`;
+
+    setTimeout(() => tooltip.remove(), 1500);
   }
 
   private hideModal(): void {

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -1205,6 +1205,15 @@ html, body {
   gap: 6px;
   align-items: center;
   justify-items: center;
+  /* Constrain width to roughly match height (5 slots × 44px + gaps) */
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .items-equip-panel {
+    max-width: 340px;
+  }
 }
 
 .items-equip-col {
@@ -4395,7 +4404,8 @@ html, body {
   gap: 6px;
   align-items: center;
   justify-items: center;
-  margin: 8px 0;
+  max-width: 240px;
+  margin: 0 auto;
 }
 .profile-equip-col {
   display: flex;

--- a/client/src/ui/ItemIcon.ts
+++ b/client/src/ui/ItemIcon.ts
@@ -11,9 +11,9 @@ export const RARITY_COLORS: Record<string, string> = {
 };
 
 export const SLOT_ICONS: Record<string, string> = {
-  head: 'H', shoulders: 'S', chest: 'C', bracers: 'B', gloves: 'G',
-  mainhand: 'M', offhand: 'O', twohanded: '2H', foot: 'F',
-  ring: 'R', necklace: 'N', back: 'K', relic: 'L',
+  head: '🪖', shoulders: '🦺', chest: '👕', bracers: '⌚', gloves: '🧤',
+  mainhand: '⚔️', offhand: '🛡️', twohanded: '🗡️', foot: '👢',
+  ring: '💍', necklace: '📿', back: '🧣', relic: '🔮',
 };
 
 export const SLOT_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- **Emoji slot icons**: Equipment slot abbreviations replaced with emoji (🪖🦺👕⌚🧤⚔️🛡️👢💍📿🧣🔮) for empty slots and inventory type indicators
- **Equipment panel sizing**: Panel width constrained to ~280px (340px desktop) so the column-silhouette-column layout stays compact and roughly square, centered horizontally
- **Empty slot tooltips**: Clicking an empty equipment slot shows a brief tooltip with the slot name (e.g. "Head", "Main Hand")
- Same layout constraints applied to the player profile equipment panel

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — all 100 tests pass
- [ ] Manual: verify emoji show in empty equipment slots
- [ ] Manual: verify equipment panel is compact and centered
- [ ] Manual: verify clicking empty slot shows tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)