### PR TITLE
Dogear slot icons, runic borders, compact equipment layout

### DIFF
--- a/client/src/screens/ItemsScreen.ts
+++ b/client/src/screens/ItemsScreen.ts
@@ -51,15 +51,37 @@ function injectItemsStyles(): void {
       text-align: center;
       line-height: 1;
     }
-    .item-square-slot-icon {
+    /* Dogear corner — white triangle in bottom-right with emoji */
+    .item-dogear {
       position: absolute;
-      bottom: 2px;
-      right: 2px;
-      font-size: 8px;
-      color: rgba(255,255,255,0.6);
+      bottom: 0;
+      right: 0;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 0 20px 20px;
+      border-color: transparent transparent #f0f0f0 transparent;
       pointer-events: none;
-      z-index: 2;
+      z-index: 3;
+      filter: drop-shadow(-1px -1px 0 rgba(0,0,0,0.3));
+    }
+    .item-dogear-icon {
+      position: absolute;
+      bottom: -20px;
+      right: -1px;
+      font-size: 10px;
       line-height: 1;
+      pointer-events: none;
+    }
+    .item-square-empty {
+      cursor: default;
+    }
+    .item-square-empty .item-dogear {
+      border-width: 0 0 18px 18px;
+    }
+    .item-square-empty .item-dogear-icon {
+      bottom: -18px;
+      font-size: 9px;
     }
     .item-square-qty {
       position: absolute;
@@ -85,19 +107,19 @@ function injectItemsStyles(): void {
       line-height: 1;
     }
 
+    /* Runic borders: gray base with glowing rarity-colored accents */
     @keyframes item-border-epic {
-      0%, 100% { border-color: #ee66e3; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(238,102,227,0.3); }
-      50% { border-color: #ff99f0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 6px rgba(255,153,240,0.5); }
+      0%, 100% { border-color: rgba(180,180,180,0.4); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(238,102,227,0.3); }
+      50% { border-color: rgba(200,200,200,0.5); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 8px rgba(238,102,227,0.6), inset 0 0 4px rgba(238,102,227,0.15); }
     }
     @keyframes item-border-legendary {
-      0% { border-color: #9233df; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(146,51,223,0.3); }
-      33% { border-color: #c77dff; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 6px rgba(199,125,255,0.5); }
-      66% { border-color: #e0aaff; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 8px rgba(224,170,255,0.6); }
-      100% { border-color: #9233df; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(146,51,223,0.3); }
+      0%, 100% { border-color: rgba(180,180,180,0.4); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(146,51,223,0.3); }
+      33% { border-color: rgba(200,200,200,0.5); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 8px rgba(199,125,255,0.6), inset 0 0 4px rgba(199,125,255,0.15); }
+      66% { border-color: rgba(210,210,210,0.5); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 12px rgba(224,170,255,0.7), inset 0 0 6px rgba(224,170,255,0.2); }
     }
     @keyframes item-border-heirloom {
-      0%, 100% { border-color: #e9bc18; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(233,188,24,0.3); }
-      50% { border-color: #fff176; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 8px rgba(255,241,118,0.6); }
+      0%, 100% { border-color: rgba(180,180,180,0.4); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 4px rgba(233,188,24,0.3); }
+      50% { border-color: rgba(200,200,200,0.5); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.3), 0 0 10px rgba(255,241,118,0.6), inset 0 0 5px rgba(255,241,118,0.15); }
     }
     .item-rarity-epic {
       animation: item-border-epic 2s ease-in-out infinite;
@@ -274,8 +296,12 @@ function injectItemsStyles(): void {
       .item-square-initials {
         font-size: 16px;
       }
-      .item-square-slot-icon {
-        font-size: 9px;
+      .item-dogear {
+        border-width: 0 0 22px 22px;
+      }
+      .item-dogear-icon {
+        bottom: -22px;
+        font-size: 11px;
       }
       .item-square-qty {
         font-size: 9px;

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -1201,19 +1201,11 @@ html, body {
 
 .items-equip-panel {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 6px;
+  grid-template-columns: auto auto auto;
+  gap: 4px 8px;
   align-items: center;
-  justify-items: center;
-  /* Constrain width to roughly match height (5 slots × 44px + gaps) */
-  max-width: 280px;
+  justify-content: center;
   margin: 0 auto;
-}
-
-@media (min-width: 768px) {
-  .items-equip-panel {
-    max-width: 340px;
-  }
 }
 
 .items-equip-col {
@@ -4400,11 +4392,10 @@ html, body {
 /* Equipment panel for profile view — mirrors items screen layout */
 .profile-equip-panel {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 6px;
+  grid-template-columns: auto auto auto;
+  gap: 4px 6px;
   align-items: center;
-  justify-items: center;
-  max-width: 240px;
+  justify-content: center;
   margin: 0 auto;
 }
 .profile-equip-col {

--- a/client/src/ui/ItemIcon.ts
+++ b/client/src/ui/ItemIcon.ts
@@ -10,6 +10,17 @@ export const RARITY_COLORS: Record<string, string> = {
   heirloom: '#e9bc18',
 };
 
+/** Border colors: gray for all rarities. Epic+ get animated glow via CSS. */
+export const RARITY_BORDER_COLORS: Record<string, string> = {
+  janky: 'rgba(180,180,180,0.25)',
+  common: 'rgba(180,180,180,0.25)',
+  uncommon: 'rgba(180,180,180,0.25)',
+  rare: 'rgba(180,180,180,0.25)',
+  epic: 'rgba(180,180,180,0.4)',
+  legendary: 'rgba(180,180,180,0.4)',
+  heirloom: 'rgba(180,180,180,0.4)',
+};
+
 export const SLOT_ICONS: Record<string, string> = {
   head: '🪖', shoulders: '🦺', chest: '👕', bracers: '⌚', gloves: '🧤',
   mainhand: '⚔️', offhand: '🛡️', twohanded: '🗡️', foot: '👢',
@@ -47,6 +58,11 @@ export function getItemSetId(itemId: string, setDefs: Record<string, SetDefiniti
   return null;
 }
 
+/** Render the dogear corner element with an optional emoji icon. */
+function renderDogear(emoji: string): string {
+  return `<span class="item-dogear"><span class="item-dogear-icon">${emoji}</span></span>`;
+}
+
 export interface ItemIconOptions {
   qty?: number;
   showSlotIcon?: boolean;
@@ -60,11 +76,12 @@ export interface ItemIconOptions {
 
 /**
  * Render a square item icon as HTML string.
- * Options control what overlays appear (qty badge, set indicator, slot icon).
+ * Options control what overlays appear (qty badge, set indicator, slot icon dogear).
  */
 export function renderItemIcon(itemId: string, def: ItemDefinition, options?: ItemIconOptions): string {
   const rarity = def.rarity ?? 'common';
   const bgColor = RARITY_COLORS[rarity] ?? '#e8e8e8';
+  const borderColor = RARITY_BORDER_COLORS[rarity] ?? 'rgba(180,180,180,0.25)';
   const shinyClass = SHINY_RARITIES.has(rarity) ? ` item-rarity-${rarity}` : '';
   const initials = getItemInitials(def.name);
   const extraClass = options?.extraClass ? ` ${options.extraClass}` : '';
@@ -87,23 +104,23 @@ export function renderItemIcon(itemId: string, def: ItemDefinition, options?: It
   if (options?.showSlotIcon && def.equipSlot) {
     const slotIcon = SLOT_ICONS[def.equipSlot] ?? '';
     if (slotIcon) {
-      inner += `<span class="item-square-slot-icon">${slotIcon}</span>`;
+      inner += renderDogear(slotIcon);
     }
   }
 
-  return `<div class="item-square${shinyClass}${extraClass}" title="${escapeHtml(def.name)}" style="background:${bgColor}"${dataStr}>${inner}</div>`;
+  return `<div class="item-square${shinyClass}${extraClass}" title="${escapeHtml(def.name)}" style="background:${bgColor};border-color:${borderColor}"${dataStr}>${inner}</div>`;
 }
 
 /**
- * Render an empty equipment slot icon.
+ * Render an empty equipment slot icon with a dogear showing the slot emoji.
  */
 export function renderEmptySlotIcon(slot: string, options?: { extraClass?: string; dataAttrs?: Record<string, string> }): string {
   const extraClass = options?.extraClass ? ` ${options.extraClass}` : '';
   const dataStr = options?.dataAttrs
     ? Object.entries(options.dataAttrs).map(([k, v]) => ` data-${k}="${escapeHtml(v)}"`).join('')
     : '';
-  const slotAbbrev = SLOT_ICONS[slot] ?? '';
+  const slotEmoji = SLOT_ICONS[slot] ?? '';
   const label = SLOT_LABELS[slot] ?? slot;
 
-  return `<div class="item-square${extraClass}" title="${escapeHtml(label)}" style="background:#333333"${dataStr}><span class="item-square-initials" style="color:rgba(255,255,255,0.3)">${slotAbbrev}</span></div>`;
+  return `<div class="item-square item-square-empty${extraClass}" title="${escapeHtml(label)}" style="background:#2a2a3a;border-color:rgba(255,255,255,0.08)"${dataStr}>${renderDogear(slotEmoji)}</div>`;
 }


### PR DESCRIPTION
## Summary
- **Dogear slot indicators**: Item type shown as a white triangle corner (bottom-right) with emoji inside and a subtle border, replacing the flat text overlay. Works on both filled items and empty equipment slots.
- **Runic borders**: All item borders are gray. Epic/legendary/heirloom items get animated glowing accents in their rarity color overlaid on the gray border (not solid colored borders).
- **Compact equipment panel**: Columns use `auto` sizing instead of `1fr` stretch — equipment slots sit right next to the silhouette, centered. Only squashes on narrow devices.
- **Empty slots**: Show the dogear with the slot emoji; main area is blank dark. Clicking still shows the slot name tooltip.
- Same layout applied to the player profile equipment panel.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — all 100 tests pass
- [ ] Manual: verify dogear corners show emoji on item squares
- [ ] Manual: verify runic glow on epic/legendary/heirloom items
- [ ] Manual: verify equipment slots hug the silhouette
- [ ] Manual: verify empty slots show dogear with slot emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)