### PR TITLE
Square dogear, bigger emoji, show on equipped items

### DIFF
--- a/client/src/screens/ItemsScreen.ts
+++ b/client/src/screens/ItemsScreen.ts
@@ -51,25 +51,25 @@ function injectItemsStyles(): void {
       text-align: center;
       line-height: 1;
     }
-    /* Dogear corner — white triangle in bottom-right with emoji */
+    /* Dogear corner — square tab in bottom-right with emoji */
     .item-dogear {
       position: absolute;
       bottom: 0;
       right: 0;
-      width: 0;
-      height: 0;
-      border-style: solid;
-      border-width: 0 0 20px 20px;
-      border-color: transparent transparent #f0f0f0 transparent;
+      width: 18px;
+      height: 18px;
+      background: rgba(240,240,240,0.85);
+      border-top-left-radius: 4px;
+      border-top: 1px solid rgba(0,0,0,0.2);
+      border-left: 1px solid rgba(0,0,0,0.2);
       pointer-events: none;
       z-index: 3;
-      filter: drop-shadow(-1px -1px 0 rgba(0,0,0,0.3));
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     .item-dogear-icon {
-      position: absolute;
-      bottom: -20px;
-      right: -1px;
-      font-size: 10px;
+      font-size: 11px;
       line-height: 1;
       pointer-events: none;
     }
@@ -77,11 +77,11 @@ function injectItemsStyles(): void {
       cursor: default;
     }
     .item-square-empty .item-dogear {
-      border-width: 0 0 18px 18px;
+      width: 16px;
+      height: 16px;
     }
     .item-square-empty .item-dogear-icon {
-      bottom: -18px;
-      font-size: 9px;
+      font-size: 10px;
     }
     .item-square-qty {
       position: absolute;
@@ -297,11 +297,11 @@ function injectItemsStyles(): void {
         font-size: 16px;
       }
       .item-dogear {
-        border-width: 0 0 22px 22px;
+        width: 22px;
+        height: 22px;
       }
       .item-dogear-icon {
-        bottom: -22px;
-        font-size: 11px;
+        font-size: 13px;
       }
       .item-square-qty {
         font-size: 9px;
@@ -505,6 +505,8 @@ export class ItemsScreen implements Screen {
       const dataAttrs: Record<string, string> = { slot, 'item-id': itemId ?? '' };
       if (def && itemId) {
         return renderItemIcon(itemId, def, {
+          showSlotIcon: true,
+          slotOverride: slot,
           showSetIndicator: true,
           setDefs: this.setDefs,
           extraClass: 'items-equip-slot-square',

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -1886,6 +1886,8 @@ export class SocialScreen implements Screen {
       const dataAttrs: Record<string, string> = { slot, 'item-id': itemId ?? '' };
       if (def && itemId) {
         return renderItemIcon(itemId, def, {
+          showSlotIcon: true,
+          slotOverride: slot,
           extraClass: 'profile-slot-square',
           dataAttrs,
         });

--- a/client/src/ui/ItemIcon.ts
+++ b/client/src/ui/ItemIcon.ts
@@ -66,6 +66,8 @@ function renderDogear(emoji: string): string {
 export interface ItemIconOptions {
   qty?: number;
   showSlotIcon?: boolean;
+  /** Override the slot used for the dogear (e.g. for equipped items where slot comes from position, not definition). */
+  slotOverride?: string;
   showSetIndicator?: boolean;
   setDefs?: Record<string, SetDefinition>;
   /** Extra CSS classes */
@@ -101,8 +103,9 @@ export function renderItemIcon(itemId: string, def: ItemDefinition, options?: It
     inner += `<span class="item-square-qty">${options.qty}</span>`;
   }
 
-  if (options?.showSlotIcon && def.equipSlot) {
-    const slotIcon = SLOT_ICONS[def.equipSlot] ?? '';
+  if (options?.showSlotIcon) {
+    const slot = options.slotOverride ?? def.equipSlot;
+    const slotIcon = slot ? (SLOT_ICONS[slot] ?? '') : '';
     if (slotIcon) {
       inner += renderDogear(slotIcon);
     }


### PR DESCRIPTION
## Summary
- **Square dogear**: Changed from triangle to a rounded square tab in the bottom-right corner with 85% opacity and subtle border on top/left edges
- **Bigger emoji**: Increased from 8-10px to 11px (13px on desktop), properly contained within the dogear without clipping
- **Equipped items show dogear**: Equipment slots now display the slot emoji dogear (was previously only on inventory items). Uses `slotOverride` to show the correct slot even for two-handed items
- **Player profile too**: Equipped items in the profile view also show the dogear
- **Popup unchanged**: The item detail popup does NOT show the dogear — slot is already visible in the text stats

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — all 100 tests pass
- [ ] Manual: verify dogear is a square tab, not triangle
- [ ] Manual: verify emoji is larger and not clipped by border
- [ ] Manual: verify equipped items show dogear with slot emoji
- [ ] Manual: verify item popup does NOT show dogear

🤖 Generated with [Claude Code](https://claude.com/claude-code)