### PR TITLE
Make tile types fully data-driven with admin CRUD

### DIFF
--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -10,7 +10,6 @@ import {
   getNeighbor,
   TILE_CONFIGS,
   HEX_SIZE,
-  TileType,
   xpForNextLevel,
   EQUIP_SLOTS,
   DISPLAY_EQUIP_SLOTS,
@@ -3534,7 +3533,7 @@ export class AdminApp {
       this.drawHex(ctx, corners, sx, sy, zoom);
 
       const ttDef = displayContent?.tileTypes?.[tile.type];
-      ctx.fillStyle = ttDef ? ttDef.color : '#' + (TILE_CONFIGS[tile.type]?.color ?? 0x333333).toString(16).padStart(6, '0');
+      ctx.fillStyle = ttDef ? ttDef.color : '#' + (TILE_CONFIGS[tile.type as import('@idle-party-rpg/shared').TileType]?.color ?? 0x333333).toString(16).padStart(6, '0');
       ctx.fill();
       ctx.strokeStyle = '#2a2a3e';
       ctx.lineWidth = 0.5;
@@ -3605,7 +3604,7 @@ export class AdminApp {
       this.drawHex(ctx, corners, sx, sy, zoom);
 
       const ttDef = displayContent?.tileTypes?.[tile.type];
-      ctx.fillStyle = ttDef ? ttDef.color : '#' + (TILE_CONFIGS[tile.type]?.color ?? 0x333333).toString(16).padStart(6, '0');
+      ctx.fillStyle = ttDef ? ttDef.color : '#' + (TILE_CONFIGS[tile.type as import('@idle-party-rpg/shared').TileType]?.color ?? 0x333333).toString(16).padStart(6, '0');
       ctx.fill();
       ctx.strokeStyle = '#2a2a3e';
       ctx.lineWidth = 0.5;
@@ -3657,7 +3656,7 @@ export class AdminApp {
       ctx.shadowOffsetY = Math.max(1, 3 * zoom);
       this.drawHex(ctx, corners, sx, sy, zoom, 1.08);
       const selTtDef = displayContent?.tileTypes?.[selectedHexTile.type];
-      ctx.fillStyle = selTtDef ? selTtDef.color : '#' + (TILE_CONFIGS[selectedHexTile.type]?.color ?? 0x333333).toString(16).padStart(6, '0');
+      ctx.fillStyle = selTtDef ? selTtDef.color : '#' + (TILE_CONFIGS[selectedHexTile.type as import('@idle-party-rpg/shared').TileType]?.color ?? 0x333333).toString(16).padStart(6, '0');
       ctx.fill();
       ctx.restore();
 
@@ -3694,7 +3693,7 @@ export class AdminApp {
   private drawNonTraversableMarker(ctx: CanvasRenderingContext2D, tile: HexTile, sx: number, sy: number, zoom: number): void {
     const displayContent = this.getDisplayContent();
     const ntDef = displayContent?.tileTypes?.[tile.type];
-    const isTraversable = ntDef ? ntDef.traversable : (TILE_CONFIGS[tile.type]?.traversable ?? true);
+    const isTraversable = ntDef ? ntDef.traversable : (TILE_CONFIGS[tile.type as import('@idle-party-rpg/shared').TileType]?.traversable ?? true);
     if (isTraversable) return;
     const size = Math.max(5, 10 * zoom);
     ctx.save();
@@ -3793,7 +3792,7 @@ export class AdminApp {
       id: '',
       col: slot.col,
       row: slot.row,
-      type: this.selectedTile?.type ?? TileType.Plains,
+      type: this.selectedTile?.type ?? 'plains',
       zone: defaultZone,
       name: this.selectedTile?.name ?? 'Default Room Name',
       encounterTable: this.selectedTile?.encounterTable
@@ -3950,7 +3949,7 @@ export class AdminApp {
     const isStart = startTile && startTile.col === tile.col && startTile.row === tile.row;
     const tileTypeDefs = displayContent ? Object.values(displayContent.tileTypes ?? {}) : [];
     const tileTypeDef = displayContent?.tileTypes?.[tile.type];
-    const isTraversable = tileTypeDef ? tileTypeDef.traversable : (TILE_CONFIGS[tile.type]?.traversable ?? false);
+    const isTraversable = tileTypeDef ? tileTypeDef.traversable : (TILE_CONFIGS[tile.type as import('@idle-party-rpg/shared').TileType]?.traversable ?? false);
     const disabled = readOnly ? ' disabled' : '';
 
     const typeOptions = tileTypeDefs
@@ -4047,7 +4046,7 @@ export class AdminApp {
 
     typeSelect?.addEventListener('change', () => {
       if (this.selectedTile) {
-        this.selectedTile.type = typeSelect.value as TileType;
+        this.selectedTile.type = typeSelect.value;
         this.scheduleSave();
         // Re-render sidebar to update start tile button visibility
         this.renderSidebar();

--- a/client/src/scenes/WorldMapScene.ts
+++ b/client/src/scenes/WorldMapScene.ts
@@ -2,7 +2,6 @@ import Phaser from 'phaser';
 import {
   HexGrid,
   HexTile,
-  TileType,
   HEX_SIZE,
   getHexCorners,
   getNeighbors,
@@ -302,7 +301,7 @@ export class WorldMapScene extends Phaser.Scene {
     const corners = getHexCorners(HEX_SIZE);
 
     for (const tile of this.grid.getAllTiles()) {
-      if (tile.type === TileType.Void) continue;
+      if (tile.type === 'void') continue;
 
       const pos = tile.pixelPosition;
       const x = pos.x + this.mapOffsetX;
@@ -359,7 +358,7 @@ export class WorldMapScene extends Phaser.Scene {
     const corners = getHexCorners(HEX_SIZE);
 
     for (const tile of this.grid.getAllTiles()) {
-      if (tile.type === TileType.Void) continue;
+      if (tile.type === 'void') continue;
       if (!tile.isTraversable) continue;
       if (tile.zone === this.currentZone) continue;
 
@@ -396,7 +395,7 @@ export class WorldMapScene extends Phaser.Scene {
     const processed = new Set<string>();
 
     for (const tile of this.grid.getAllTiles()) {
-      if (tile.type === TileType.Void) continue;
+      if (tile.type === 'void') continue;
 
       const neighbors = getNeighbors(tile.coord);
       for (let dir = 0; dir < 6; dir++) {
@@ -435,7 +434,7 @@ export class WorldMapScene extends Phaser.Scene {
   }
 
   private drawTileIcon(
-    type: TileType,
+    type: string,
     isTraversable: boolean,
     isZoneUnlocked: boolean,
     isUnlocked: boolean,
@@ -622,14 +621,7 @@ export class WorldMapScene extends Phaser.Scene {
       this.onTileClickFn({
         col: offset.col,
         row: offset.row,
-        tileType: tile.type === TileType.Town ? 'Town'
-          : tile.type === TileType.Forest ? 'Forest'
-          : tile.type === TileType.Plains ? 'Plains'
-          : tile.type === TileType.Dungeon ? 'Dungeon'
-          : tile.type === TileType.Desert ? 'Desert'
-          : tile.type === TileType.LavaField ? 'Lava Field'
-          : tile.type === TileType.Beach ? 'Beach'
-          : 'Unknown',
+        tileType: this.worldCache.getTileTypeDef(tile.type)?.name ?? tile.type,
         zoneName,
         roomName,
         zoneId: tile.zone,
@@ -684,11 +676,7 @@ export class WorldMapScene extends Phaser.Scene {
 
     // Non-traversable tiles always show their terrain type name
     if (!tile.isTraversable) {
-      const typeLabel = tile.type === TileType.Mountain ? 'Mountain'
-        : tile.type === TileType.Water ? 'Water'
-        : tile.type === TileType.Hedge ? 'Hedge'
-        : tile.type === TileType.Volcano ? 'Volcano'
-        : tile.type.charAt(0).toUpperCase() + tile.type.slice(1);
+      const typeLabel = this.worldCache.getTileTypeDef(tile.type)?.name ?? tile.type;
       this.tooltipText.setText(typeLabel);
       this.tooltipText.setPosition(pointer.x + 12, pointer.y - 20);
       this.tooltipText.setVisible(true);

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -3994,7 +3994,8 @@ html, body {
 
 /* --- Encounter Modal --- */
 
-.admin-encounter-modal-overlay {
+.admin-encounter-modal-overlay,
+.admin-modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -4005,6 +4006,54 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.admin-modal {
+  background: var(--bg-darker, #1a1a2e);
+  border: 2px solid var(--border-pixel, #555);
+  width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
+  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-size: 8px;
+  color: var(--text-primary, #eee);
+  padding: 16px;
+}
+
+.admin-modal h3 {
+  margin: 0 0 12px 0;
+  font-size: 10px;
+  color: var(--accent-gold, #f5c842);
+}
+
+.admin-modal .admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-modal .admin-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-secondary, #aaa);
+}
+
+.admin-modal .admin-form input,
+.admin-modal .admin-form select {
+  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-size: 8px;
+  background: var(--bg-input, #0d1b2a);
+  color: var(--text-primary, #eee);
+  border: 1px solid var(--border-pixel, #555);
+  padding: 6px 8px;
+}
+
+.admin-modal .admin-modal-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  justify-content: flex-end;
 }
 
 .admin-encounter-modal {

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -955,7 +955,15 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
     if (snapshot.shops) {
       for (const s of snapshot.shops) shopsRecord[s.id] = s;
     }
-    res.json({ monsters: monstersRecord, items: itemsRecord, zones: zonesRecord, encounters: encountersRecord, sets: setsRecord, shops: shopsRecord, world: snapshot.world });
+    const tileTypesRecord: Record<string, NonNullable<(typeof snapshot.tileTypes)>[0]> = {};
+    if (snapshot.tileTypes && snapshot.tileTypes.length > 0) {
+      for (const t of snapshot.tileTypes) tileTypesRecord[t.id] = t;
+    } else {
+      // Old snapshots predate tile types — seed from live content
+      const liveTileTypes = getContentStore().getAllTileTypes();
+      for (const [id, t] of Object.entries(liveTileTypes)) tileTypesRecord[id] = t;
+    }
+    res.json({ monsters: monstersRecord, items: itemsRecord, zones: zonesRecord, encounters: encountersRecord, sets: setsRecord, shops: shopsRecord, tileTypes: tileTypesRecord, world: snapshot.world });
   });
 
   /** Rename a draft version. */

--- a/server/src/game/ContentStore.ts
+++ b/server/src/game/ContentStore.ts
@@ -175,7 +175,7 @@ export class ContentStore {
       return { success: false, error: 'Tile not found.' };
     }
     const tileTypeDef = this.tileTypes.get(tile.type);
-    const isTraversable = tileTypeDef ? tileTypeDef.traversable : (TILE_CONFIGS[tile.type]?.traversable ?? false);
+    const isTraversable = tileTypeDef ? tileTypeDef.traversable : (TILE_CONFIGS[tile.type as TileType]?.traversable ?? false);
     if (!isTraversable) {
       return { success: false, error: 'Start tile must be traversable.' };
     }

--- a/shared/src/hex/HexTile.ts
+++ b/shared/src/hex/HexTile.ts
@@ -112,22 +112,20 @@ export const SEED_TILE_TYPES: TileTypeDefinition[] = [
 
 export class HexTile {
   readonly coord: CubeCoord;
-  readonly type: TileType;
-  readonly config: TileConfig;
+  readonly type: string;
   readonly key: string;
   readonly zone: string;
   /** Stable GUID from WorldTileDefinition — used as unlock key. */
   readonly id: string;
-  /** Per-tile override for required item. Takes precedence over TileConfig default. */
+  /** Per-tile override for required item. Takes precedence over tile type default. */
   private readonly _requiredItemId?: string;
 
-  /** Optional data-driven tile type definition from ContentStore. */
+  /** Data-driven tile type definition from ContentStore. */
   private readonly _tileTypeDef?: TileTypeDefinition;
 
-  constructor(coord: CubeCoord, type: TileType, zone: string = 'friendly_forest', id?: string, requiredItemId?: string, tileTypeDef?: TileTypeDefinition) {
+  constructor(coord: CubeCoord, type: string, zone: string = 'friendly_forest', id?: string, requiredItemId?: string, tileTypeDef?: TileTypeDefinition) {
     this.coord = coord;
     this.type = type;
-    this.config = TILE_CONFIGS[type] ?? TILE_CONFIGS[TileType.Plains];
     this.key = cubeToKey(coord);
     this.zone = zone;
     this.id = id ?? this.key; // Fallback to cube key for legacy/test usage
@@ -137,17 +135,19 @@ export class HexTile {
 
   get isTraversable(): boolean {
     if (this._tileTypeDef) return this._tileTypeDef.traversable;
-    return this.config.traversable;
+    // Fallback for tiles without a definition (legacy/test)
+    const config = TILE_CONFIGS[this.type as TileType];
+    return config?.traversable ?? true;
   }
 
   get requiredItemId(): string | undefined {
-    // Per-tile override takes precedence, then tile type default
     return this._requiredItemId ?? this._tileTypeDef?.requiredItemId;
   }
 
   get color(): number {
     if (this._tileTypeDef) return parseInt(this._tileTypeDef.color.replace('#', ''), 16);
-    return this.config.color;
+    const config = TILE_CONFIGS[this.type as TileType];
+    return config?.color ?? 0x888888;
   }
 
   get pixelPosition(): { x: number; y: number } {

--- a/shared/src/hex/MapSchema.ts
+++ b/shared/src/hex/MapSchema.ts
@@ -14,7 +14,7 @@ export interface MapSchema {
 export interface TileDefinition {
   col: number;
   row: number;
-  type: TileType;
+  type: string;
 }
 
 /**
@@ -26,7 +26,7 @@ export interface WorldTileDefinition {
   id: string;
   col: number;
   row: number;
-  type: TileType;
+  type: string;
   zone: string;
   name: string;
   /** Zone display name — populated by server when sending to clients, not stored in world.json. */


### PR DESCRIPTION
## Summary
- Tile type fields (`WorldTileDefinition.type`, `HexTile.type`) changed from `TileType` enum to `string`, enabling custom tile types created in admin
- Added CSS for admin modal overlay so the "New Tile Type" button works
- WorldMapScene uses tile type definitions for icons, names, and colors instead of hardcoded switch statements
- Fixed version content API (`GET /versions/:id/content`) not including `tileTypes` in response
- Old version snapshots that predate tile types fall back to live content

## Test plan
- [ ] Tile Types tab shows all seed tile types (Plains, Forest, Town, etc.)
- [ ] Create a new custom tile type, assign it to a world tile
- [ ] Edit an existing tile type (change color/icon/traversable) — map updates
- [ ] Delete a tile type not in use — succeeds; delete one in use — blocked with error
- [ ] Map renders correctly with data-driven icons and colors
- [ ] `npm run test` passes (120 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)