### PR TITLE
Fix tile type editing, admin refresh, and version snapshots

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,6 +12,18 @@ export default defineConfig({
       },
     },
   },
+  // Rewrite /admin routes to admin.html in dev (SPA fallback for multi-page app)
+  plugins: [{
+    name: 'admin-spa-fallback',
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        if (req.url && req.url.startsWith('/admin') && !req.url.includes('.')) {
+          req.url = '/admin.html';
+        }
+        next();
+      });
+    },
+  }],
   server: {
     port: 3000,
     open: true,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import path from 'path';
 
 export default defineConfig({
-  base: './',
+  base: '/',
   build: {
     outDir: 'dist',
     rollupOptions: {

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -841,7 +841,10 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
       if (!version) { res.status(404).json({ error: 'Version not found.' }); return; }
       if (version.status !== 'draft') { res.status(400).json({ error: 'Only drafts can be edited.' }); return; }
       const snapshot = await versions.loadSnapshot(versionId);
-      if (!snapshot.tileTypes) snapshot.tileTypes = [];
+      if (!snapshot.tileTypes || snapshot.tileTypes.length === 0) {
+        // Old snapshot predates tile types — seed from live content
+        snapshot.tileTypes = Object.values(getContentStore().getAllTileTypes());
+      }
       const idx = snapshot.tileTypes.findIndex(t => t.id === tileTypeId);
       if (idx >= 0) snapshot.tileTypes[idx] = def;
       else snapshot.tileTypes.push(def);
@@ -866,7 +869,9 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
       if (!version) { res.status(404).json({ error: 'Version not found.' }); return; }
       if (version.status !== 'draft') { res.status(400).json({ error: 'Only drafts can be edited.' }); return; }
       const snapshot = await versions.loadSnapshot(versionId);
-      if (!snapshot.tileTypes) snapshot.tileTypes = [];
+      if (!snapshot.tileTypes || snapshot.tileTypes.length === 0) {
+        snapshot.tileTypes = Object.values(getContentStore().getAllTileTypes());
+      }
       // Check referential integrity
       for (const tile of snapshot.world.tiles) {
         if (tile.type === tileTypeId) {


### PR DESCRIPTION
## Summary
- **Tile types fully data-driven**: `WorldTileDefinition.type` and `HexTile.type` changed from `TileType` enum to `string`, enabling custom tile types
- **Fix tile type edit wiping others**: Old version snapshots had no `tileTypes` array, so editing one type deleted the rest. Now seeds from live content when snapshot is empty.
- **Fix New Tile Type modal**: Added CSS for `admin-modal-overlay` so the modal actually renders
- **Fix admin blank screen on refresh**: Production `base` was `'./'` (relative), so `/admin` resolved assets to `/admin/assets/*` instead of `/assets/*`. Changed to `'/'`. Also added dev SPA fallback for `/admin` routes.
- **WorldMapScene data-driven**: Icons, names, and colors all read from tile type definitions instead of hardcoded switch statements

## Test plan
- [ ] Tile Types tab shows all seed types on first load
- [ ] Edit a tile type — other types persist
- [ ] Create a new custom tile type, assign to a tile
- [ ] Delete unused tile type — succeeds; delete used one — blocked
- [ ] `/admin` page refresh works in production (no blank screen)
- [ ] `npm run build` then verify admin.html uses `/assets/` (absolute) paths
- [ ] Map renders with data-driven icons and colors
- [ ] `npm run test` passes (120 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)