### PR TITLE
Fix tile types lost on deploy and add version bar

### DIFF
--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -2764,6 +2764,8 @@ export class AdminApp {
     if (!displayContent) return '<div class="admin-page-empty">No data</div>';
     const tileTypes = Object.values(displayContent.tileTypes ?? {});
     const items = displayContent.items;
+    const readOnly = this.isReadOnly();
+    const versionBar = this.renderVersionBar();
 
     const rows = tileTypes.map(t => {
       const itemName = t.requiredItemId ? (items[t.requiredItemId]?.name ?? t.requiredItemId) : '';
@@ -2774,16 +2776,19 @@ export class AdminApp {
         <td><span class="color-swatch" style="background:${this.escapeHtml(t.color)}"></span> ${this.escapeHtml(t.color)}</td>
         <td>${t.traversable ? 'Yes' : 'No'}</td>
         <td>${this.escapeHtml(itemName)}</td>
-        <td>
+        <td>${readOnly ? '' : `
           <button class="admin-btn admin-btn-sm tile-type-edit-btn" data-id="${this.escapeHtml(t.id)}">Edit</button>
           <button class="admin-btn admin-btn-sm admin-btn-danger tile-type-delete-btn" data-id="${this.escapeHtml(t.id)}">Del</button>
-        </td>
+        `}</td>
       </tr>`;
     }).join('');
 
+    const newBtn = readOnly ? '' : '<button class="admin-btn tile-type-new-btn">+ New Tile Type</button>';
+
     return `<div class="admin-page">
+      ${versionBar}
       <h2>Tile Types (${tileTypes.length})</h2>
-      <button class="admin-btn tile-type-new-btn">+ New Tile Type</button>
+      ${newBtn}
       <table class="admin-table">
         <thead><tr><th>Icon</th><th>ID</th><th>Name</th><th>Color</th><th>Walk</th><th>Req. Item</th><th></th></tr></thead>
         <tbody>${rows}</tbody>
@@ -2806,6 +2811,9 @@ export class AdminApp {
     });
     document.querySelector('.tile-type-new-btn')?.addEventListener('click', () => {
       this.openTileTypeModal(null);
+    });
+    document.getElementById('version-bar-view-active')?.addEventListener('click', () => {
+      if (this.activeVersionId) this.selectVersion(this.activeVersionId);
     });
   }
 

--- a/server/src/game/ContentStore.ts
+++ b/server/src/game/ContentStore.ts
@@ -370,10 +370,11 @@ export class ContentStore {
       for (const s of snapshot.shops) this.shops.set(s.id, s);
     }
 
-    this.tileTypes.clear();
-    if (snapshot.tileTypes) {
+    if (snapshot.tileTypes && snapshot.tileTypes.length > 0) {
+      this.tileTypes.clear();
       for (const t of snapshot.tileTypes) this.tileTypes.set(t.id, t);
     }
+    // Old snapshots predate tile types — keep existing tile types intact
 
     this.world = snapshot.world;
 


### PR DESCRIPTION
## Summary
- **Fix tile types wiped on deploy/rollback**: `replaceAll()` was clearing tile types when deploying snapshots that predate the tile types feature. Now preserves existing tile types when the snapshot has none.
- **Fix icons disappearing**: Same root cause — client got empty tile type defs from `/api/world` after a deploy, so map rendered with no icons.
- **Fix requiredItemId not working after deploy**: Tile type defaults were lost with the wipe.
- **Add version bar to Tile Types tab**: Shows version name, status badge, and "View Active" button. Edit/delete/new buttons hidden on read-only versions.

## Test plan
- [ ] Deploy a version → tile types and map icons persist
- [ ] Rollback to older version → tile types still intact
- [ ] Tile Types tab shows version bar with correct version name
- [ ] Read-only version hides edit/delete/new buttons
- [ ] Edit tile type with requiredItemId, deploy, verify movement is blocked without item

🤖 Generated with [Claude Code](https://claude.com/claude-code)