### PR TITLE
Add restore seed data button for tile types

### DIFF
--- a/client/src/admin/AdminApp.ts
+++ b/client/src/admin/AdminApp.ts
@@ -2784,11 +2784,14 @@ export class AdminApp {
     }).join('');
 
     const newBtn = readOnly ? '' : '<button class="admin-btn tile-type-new-btn">+ New Tile Type</button>';
+    const seedBtn = !readOnly && tileTypes.length === 0
+      ? '<button class="admin-btn tile-type-seed-btn" style="margin-left:8px">Restore Seed Data</button>'
+      : '';
 
     return `<div class="admin-page">
       ${versionBar}
       <h2>Tile Types (${tileTypes.length})</h2>
-      ${newBtn}
+      ${newBtn}${seedBtn}
       <table class="admin-table">
         <thead><tr><th>Icon</th><th>ID</th><th>Name</th><th>Color</th><th>Walk</th><th>Req. Item</th><th></th></tr></thead>
         <tbody>${rows}</tbody>
@@ -2811,6 +2814,9 @@ export class AdminApp {
     });
     document.querySelector('.tile-type-new-btn')?.addEventListener('click', () => {
       this.openTileTypeModal(null);
+    });
+    document.querySelector('.tile-type-seed-btn')?.addEventListener('click', () => {
+      this.seedTileTypes();
     });
     document.getElementById('version-bar-view-active')?.addEventListener('click', () => {
       if (this.activeVersionId) this.selectVersion(this.activeVersionId);
@@ -2897,6 +2903,23 @@ export class AdminApp {
       this.renderTabContent();
     } catch {
       alert('Network error — could not delete tile type');
+    }
+  }
+
+  private async seedTileTypes(): Promise<void> {
+    if (!confirm('Restore default tile types? This will add any missing seed types.')) return;
+    try {
+      const qp = this.versionQueryParam();
+      const res = await fetch(`/api/admin/tile-types/seed${qp}`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (!res.ok) { alert(data.error || 'Failed to seed tile types'); return; }
+      this.updateDisplayTileTypes(data.tileTypes);
+      this.renderTabContent();
+    } catch {
+      alert('Network error — could not seed tile types');
     }
   }
 

--- a/server/src/admin/adminRoutes.ts
+++ b/server/src/admin/adminRoutes.ts
@@ -7,7 +7,7 @@ import type { PlayerManager } from '../game/PlayerManager.js';
 import type { AccountStore } from '../auth/AccountStore.js';
 import type { ContentStore } from '../game/ContentStore.js';
 import type { VersionStore } from '../game/VersionStore.js';
-import { ALL_CLASS_NAMES } from '@idle-party-rpg/shared';
+import { ALL_CLASS_NAMES, SEED_TILE_TYPES } from '@idle-party-rpg/shared';
 import type { ClassName } from '@idle-party-rpg/shared';
 import { adminMiddleware } from './adminMiddleware.js';
 
@@ -890,6 +890,36 @@ export function createAdminRoutes({ playerManager: getPlayerManager, accountStor
       if (!result.success) {
         res.status(400).json({ error: result.error });
         return;
+      }
+      res.json({ success: true, tileTypes: content.getAllTileTypes() });
+    }
+  });
+
+  /** Restore seed tile types (adds any missing defaults). */
+  router.post('/tile-types/seed', async (req, res) => {
+    const versionId = req.query.versionId as string | undefined;
+
+    if (versionId) {
+      const versions = getVersionStore();
+      const version = versions.get(versionId);
+      if (!version) { res.status(404).json({ error: 'Version not found.' }); return; }
+      if (version.status !== 'draft') { res.status(400).json({ error: 'Only drafts can be edited.' }); return; }
+      const snapshot = await versions.loadSnapshot(versionId);
+      if (!snapshot.tileTypes) snapshot.tileTypes = [];
+      const existingIds = new Set(snapshot.tileTypes.map(t => t.id));
+      for (const seed of SEED_TILE_TYPES) {
+        if (!existingIds.has(seed.id)) snapshot.tileTypes.push(seed);
+      }
+      await versions.saveSnapshot(versionId, snapshot);
+      const record: Record<string, import('@idle-party-rpg/shared').TileTypeDefinition> = {};
+      for (const t of snapshot.tileTypes) record[t.id] = t;
+      res.json({ success: true, tileTypes: record });
+    } else {
+      const content = getContentStore();
+      for (const seed of SEED_TILE_TYPES) {
+        if (!content.getTileType(seed.id)) {
+          await content.addOrUpdateTileType(seed);
+        }
       }
       res.json({ success: true, tileTypes: content.getAllTileTypes() });
     }


### PR DESCRIPTION
## Summary
- When Tile Types tab is empty (broken deploy, rollback, etc.), a "Restore Seed Data" button appears
- Calls `POST /tile-types/seed` which adds all missing default tile types from `SEED_TILE_TYPES`
- Only adds missing types — won't overwrite existing customized ones
- Works on both live content and draft versions

## Test plan
- [ ] Clear tile types (or deploy old version) → button appears
- [ ] Click "Restore Seed Data" → all 12 seed types populate
- [ ] Button hidden when tile types already exist
- [ ] Button hidden on read-only versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)