### PR TITLE
Fix holy damage log when physical fully resisted (#333)

### DIFF
--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -1,5 +1,11 @@
 export const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.05.02.1',
+    notes: [
+      'Bug fix: Priest Blessed Arms holy damage was being mislabeled as physical damage in the combat log when the physical hit was fully resisted. The HP math was always correct; now the log correctly shows "0 physical + X holy" so it\'s clear holy damage isn\'t blocked by physical resistance',
+    ],
+  },
+  {
     version: '2026.04.29.3',
     notes: [
       'Sets now support breakpoints — partial set rewards at e.g. 2/4 and 4/4 pieces. Item tooltips show every tier and highlight the one currently active',

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -22,7 +22,7 @@ export type PartyState = 'idle' | 'moving' | 'in_battle';
 export const RESULT_PAUSE = 600;      // ms to show victory/defeat before movement
 export const MOVE_DURATION = 400;     // ms for tile movement (client animation)
 export const RUN_AVAILABLE_ROUNDS = 5; // rounds before "Run" becomes available
-export const GAME_VERSION = '2026.04.29.3'; // Keep in sync with PATCH_NOTES in client
+export const GAME_VERSION = '2026.05.02.1'; // Keep in sync with PATCH_NOTES in client
 
 // --- Protocol types (server → client, client → server) ---
 

--- a/shared/src/systems/CombatEngine.ts
+++ b/shared/src/systems/CombatEngine.ts
@@ -609,10 +609,10 @@ function applyDamageToMonster(
   target.currentHp = Math.max(0, target.currentHp - totalDamage);
 
   const verb = skillName ? `uses ${skillName} on` : 'hits';
-  if (holyDamage > 0 && damage > 0) {
+  if (holyDamage > 0) {
     logEntries.push(`${player.username} ${verb} ${target.name} for ${damage} ${player.playerDamageType} + ${holyDamage} holy damage`);
   } else {
-    logEntries.push(`${player.username} ${verb} ${target.name} for ${totalDamage} ${player.playerDamageType} damage`);
+    logEntries.push(`${player.username} ${verb} ${target.name} for ${damage} ${player.playerDamageType} damage`);
   }
 
   // Apply Scorch debuff if Mage has it equipped


### PR DESCRIPTION
## Summary
- When Priest Blessed Arms holy damage was added to a player attack whose physical component had been resisted to 0, the combat log labelled the *entire* hit as physical (e.g., "Knight hits Goblin for 5 physical damage" when it was really 0 physical + 5 holy). The HP math was always correct — only the log was wrong.
- Per design decision: holy damage is added on top of 0 physical, **not** blocked. The log now always shows the "X physical + Y holy" breakdown when holy is present, making it clear that holy damage bypasses physical resistance.
- Bumps `GAME_VERSION` to `2026.05.02.1` so the server auto-broadcasts the update to connected players, and adds a patch notes entry.

Fixes #333.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test:shared` — all 314 tests pass
- [ ] Manually verify in-game: equip a Priest with Blessed Arms, attack a monster with high physical resistance, confirm log shows `0 physical + N holy damage`
- [ ] Confirm normal attacks (no holy) still log as `N physical damage` with no breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)