### PR TITLE
UI fixes: trade scroll, chat-from-popup, run hint, future skills

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -476,6 +476,13 @@ export class App {
     this.chatPopout.setOnClose(() => nav.setOverlayActive('chat', false));
     this.chatPopout.setOnUnreadChange((hasUnread) => nav.setChatUnread(hasUnread));
 
+    // Wire user-popup "Chat" action → open the chat popout in DM mode and
+    // light up the Chat nav button.
+    socialScreen.setOnDmRequest((username) => {
+      this.chatPopout?.openDm(username);
+      nav.setOverlayActive('chat', true);
+    });
+
     // Restore chat open/closed from the previous session on this browser.
     if (this.chatPopout.wasOpen()) {
       this.chatPopout.open();

--- a/client/src/screens/CharItemsScreen.ts
+++ b/client/src/screens/CharItemsScreen.ts
@@ -15,7 +15,9 @@ import {
   classIconHtml,
   SKILL_SLOTS,
   CLASS_DEFINITIONS,
+  SKILL_TREES,
   getSkillById,
+  getSkillLearnLevel,
   getOwnedItemIds,
   getEquippedItemIds,
 } from '@idle-party-rpg/shared';
@@ -193,6 +195,16 @@ function injectCharItemsStyles(): void {
     }
     .charitems-skill-row.passive { border-left: 4px solid #5c8a5c; }
     .charitems-skill-row.active { border-left: 4px solid #c89b3c; }
+    .charitems-skill-row.locked {
+      opacity: 0.55;
+      cursor: default;
+    }
+    .charitems-skill-row.locked:hover { border-color: #333; }
+    .charitems-skill-row-locklabel {
+      font-size: 10px;
+      color: var(--accent-gold, #c89b3c);
+      text-transform: uppercase;
+    }
     .charitems-skill-row-name {
       font-size: 13px;
       color: #f5f5f5;
@@ -1033,18 +1045,28 @@ export class CharItemsScreen implements Screen {
     const equippedNow = equippedId ? getSkillById(equippedId) : null;
 
     const equippedIds = new Set(char.skillLoadout.equippedSkills.filter(Boolean) as string[]);
-    const candidates: SkillDefinition[] = [];
-    for (const id of char.skillLoadout.unlockedSkills) {
-      const skill = getSkillById(id);
-      if (!skill) continue;
+    const unlockedIds = new Set(char.skillLoadout.unlockedSkills);
+    const classTree = SKILL_TREES[char.className] ?? [];
+
+    // Build a single list of candidates (unlocked + future-locked) so the
+    // player can see what's coming. Locked rows are visually dimmed and
+    // non-clickable; unlocked rows behave as before.
+    type Candidate = { skill: SkillDefinition; locked: boolean };
+    const candidates: Candidate[] = [];
+    for (const skill of classTree) {
       if (skill.type !== slot.type) continue;
-      // Allow showing the currently-equipped skill so it's visible (but disabled — clicking does nothing)
-      if (equippedIds.has(id) && id !== equippedId) continue;
-      candidates.push(skill);
+      const isUnlocked = unlockedIds.has(skill.id);
+      if (isUnlocked) {
+        // Hide already-equipped-elsewhere unlocked skills (the existing rule).
+        if (equippedIds.has(skill.id) && skill.id !== equippedId) continue;
+        candidates.push({ skill, locked: false });
+      } else {
+        candidates.push({ skill, locked: true });
+      }
     }
 
     // Sort by treeOrder (level acquired)
-    candidates.sort((a, b) => a.treeOrder - b.treeOrder);
+    candidates.sort((a, b) => a.skill.treeOrder - b.skill.treeOrder);
 
     const overlay = document.createElement('div');
     overlay.className = 'charitems-skill-popup-overlay';
@@ -1053,11 +1075,21 @@ export class CharItemsScreen implements Screen {
     if (candidates.length === 0) {
       rowsHtml = `<div class="charitems-skill-popup-empty">No other ${slot.type} skills available.</div>`;
     } else {
-      rowsHtml = candidates.map(s => {
+      rowsHtml = candidates.map(({ skill: s, locked }) => {
         const isCurrent = s.id === equippedId;
-        return `<div class="charitems-skill-row ${s.type}" data-skill-id="${s.id}" ${isCurrent ? 'data-current="1"' : ''}>
+        const learnLevel = getSkillLearnLevel(s.treeOrder);
+        const classes = ['charitems-skill-row', s.type];
+        if (locked) classes.push('locked');
+        const attrs = locked
+          ? `data-locked="1"`
+          : `data-skill-id="${s.id}" ${isCurrent ? 'data-current="1"' : ''}`;
+        const tagline = locked
+          ? `<div class="charitems-skill-row-locklabel">Unlocks at Lv ${learnLevel}</div>`
+          : '';
+        return `<div class="${classes.join(' ')}" ${attrs}>
           <div class="charitems-skill-row-name">${this.escapeHtml(s.name)}${isCurrent ? ' &middot; equipped' : ''}</div>
           <div class="charitems-skill-row-meta">${s.type}${s.cooldown ? ` &middot; CD ${s.cooldown}` : ''}</div>
+          ${tagline}
           <div class="charitems-skill-row-desc">${this.escapeHtml(s.description)}</div>
         </div>`;
       }).join('');
@@ -1092,6 +1124,7 @@ export class CharItemsScreen implements Screen {
 
     overlay.querySelectorAll<HTMLElement>('.charitems-skill-row').forEach(row => {
       row.addEventListener('click', () => {
+        if (row.getAttribute('data-locked') === '1') return;
         const id = row.getAttribute('data-skill-id');
         const isCurrent = row.getAttribute('data-current') === '1';
         if (!id || isCurrent) return;

--- a/client/src/screens/CombatScreen.ts
+++ b/client/src/screens/CombatScreen.ts
@@ -511,8 +511,11 @@ export class CombatScreen implements Screen {
     this.runBar.style.display = this.isFullscreen ? 'none' : '';
     this.runBar.classList.remove('combat-run-bar-empty');
 
+    // Never set `disabled` on the run button \u2014 disabled <button>s swallow
+    // click events on mobile, which kills the locked-state hint tap. We use
+    // the .combat-run-locked class for visual state instead and gate the
+    // click handler on the class.
     if (!isFighting) {
-      this.runBtn.disabled = true;
       this.runBtn.classList.add('combat-run-locked');
       this.runBtn.textContent = '\uD83D\uDD12 Run';
       this.runHint.textContent = '';
@@ -520,7 +523,6 @@ export class CombatScreen implements Screen {
     }
 
     if (!canRun) {
-      this.runBtn.disabled = true;
       this.runBtn.classList.add('combat-run-locked');
       this.runBtn.textContent = '\uD83D\uDD12 Run';
       this.runHint.textContent = 'Only the party owner or a leader can run';
@@ -528,7 +530,6 @@ export class CombatScreen implements Screen {
     }
 
     const available = roundCount >= RUN_AVAILABLE_ROUNDS;
-    this.runBtn.disabled = !available;
     this.runBtn.classList.toggle('combat-run-locked', !available);
     this.runBtn.textContent = available ? 'Run' : '\uD83D\uDD12 Run';
     this.runHint.textContent = `Available after ${RUN_AVAILABLE_ROUNDS} combat rounds`;

--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -1,5 +1,15 @@
 export const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.05.13.1',
+    notes: [
+      'Trade modal: the item picker now uses a frozen inventory snapshot taken when you open the modal, so the global tick no longer rebuilds the list and yanks you back to the top. The server validates the offer at submission time, as before',
+      'Chat with user: clicking Chat on a user popup now opens the global chat pop-out pre-filled for a DM to that player',
+      'Mobile chat: opening the chat pop-out no longer steals focus / pops the soft keyboard over the timeline — tap the input when you actually want to type',
+      'Combat: tapping the locked Run button on mobile shows the "Available after 5 rounds" hint again (the disabled attribute was swallowing the click)',
+      'Skill slot picker: future skills you have not unlocked yet show up as dimmed rows with "Unlocks at Lv X" so you can preview what is coming',
+    ],
+  },
+  {
     version: '2026.05.11.1',
     notes: [
       'Admin: artwork upload added to all CRM entities (monsters, sets, shops, zones, tile types) — same pipeline as items',

--- a/client/src/screens/SocialScreen.ts
+++ b/client/src/screens/SocialScreen.ts
@@ -1,6 +1,6 @@
 import type { GameClient } from '../network/GameClient';
 import type { ChatLocalStore } from '../network/ChatLocalStore';
-import type { ServerStateMessage, ClientSocialState, ChatMessage, ChatChannelType, PlayerListEntry, PlayerProfileMessage, TradeOfferItem, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
+import type { ServerStateMessage, ClientSocialState, ChatMessage, ChatChannelType, PlayerListEntry, PlayerProfileMessage, TradeOfferItem, TradeState, ItemDefinition, SetDefinition } from '@idle-party-rpg/shared';
 import { MAX_PARTY_SIZE, classIconHtml, serverIconHtml, getItemEffectText, SKILL_SLOTS, getSkillById, listUnequippedEntries, getEquippedItemIds } from '@idle-party-rpg/shared';
 import type { Screen } from './ScreenManager';
 import { RARITY_COLORS, renderItemIcon, renderEmptySlotIcon } from '../ui/ItemIcon';
@@ -50,6 +50,9 @@ export class SocialScreen implements Screen {
   // User popup
   private popupOverlay: HTMLElement | null = null;
 
+  /** Wired by App.ts to open the chat popout pre-filled for a DM target. */
+  private onDmRequest?: (username: string) => void;
+
   // Trade modal
   private tradeModalEl: HTMLElement | null = null;
   private tradeSelectedItems = new Map<string, number>(); // itemId → quantity
@@ -57,6 +60,19 @@ export class SocialScreen implements Screen {
   private tradeActiveId: string | null = null;
   /** When proposing a new trade, the target username. */
   private tradeTargetUsername: string | null = null;
+  /**
+   * Inventory frozen at modal-open time. The picker renders from this snapshot
+   * for the modal's whole lifetime so the global state tick doesn't disturb
+   * the user's selection (issue #342). The server is the authority on whether
+   * the offer is still valid at submission time.
+   */
+  private tradeInventorySnapshot: Record<string, number> | null = null;
+  /**
+   * Last-rendered trade-state fingerprint. Tick-driven updates skip the
+   * innerHTML rewrite when this hasn't changed, which is the common case
+   * while the user is choosing items.
+   */
+  private lastTradeRenderKey = '';
 
   // Gift modal
   private giftModalEl: HTMLElement | null = null;
@@ -1282,16 +1298,20 @@ export class SocialScreen implements Screen {
   }
 
   /**
-   * Pre-select a DM target. (The chat sub-tab is gone — chat is a global pop-out;
-   * this just records the prefs server-side so when the user opens the popout
-   * the DM target is remembered. The popout itself doesn't yet read prefs at
-   * open-time, but storing them keeps cross-device sync intact.)
+   * Open the chat popout pre-filled for a DM to `username`. Also persists
+   * the choice as the user's chat preferences for cross-device sync.
    */
   startDm(username: string): void {
     this.chatSendChannel = 'dm';
     this.chatDmTarget = username;
     this.gameClient.sendSetChatPreferences(this.chatSendChannel, this.chatDmTarget);
     this.chatFocusAfterRender = true;
+    this.onDmRequest?.(username);
+  }
+
+  /** Wire an external handler that opens the global chat popout to a DM. */
+  setOnDmRequest(cb: (username: string) => void): void {
+    this.onDmRequest = cb;
   }
 
 
@@ -1433,6 +1453,7 @@ export class SocialScreen implements Screen {
     this.tradeActiveId = null;
     this.tradeTargetUsername = targetUsername;
     this.tradeSelectedItems = new Map();
+    this.snapshotInventoryForTrade();
     this.renderTradeModal();
   }
 
@@ -1441,7 +1462,14 @@ export class SocialScreen implements Screen {
     this.tradeActiveId = tradeId;
     this.tradeTargetUsername = null;
     this.tradeSelectedItems = new Map();
+    this.snapshotInventoryForTrade();
     this.renderTradeModal();
+  }
+
+  private snapshotInventoryForTrade(): void {
+    const inv = this.lastState?.character?.inventory ?? {};
+    this.tradeInventorySnapshot = { ...inv };
+    this.lastTradeRenderKey = '';
   }
 
   /** Find the active trade for this modal in social state. */
@@ -1494,7 +1522,7 @@ export class SocialScreen implements Screen {
       if (btn.matches('.trade-qty-inc')) {
         const itemId = btn.getAttribute('data-item-id');
         if (!itemId) return;
-        const inventory = this.lastState?.character?.inventory ?? {};
+        const inventory = this.tradeInventorySnapshot ?? {};
         const maxQty = (inventory[itemId] as number) ?? 0;
         const current = this.tradeSelectedItems.get(itemId) ?? 0;
         if (current < maxQty) {
@@ -1549,7 +1577,18 @@ export class SocialScreen implements Screen {
     const trade = this.getActiveTrade();
     const selfUsername = this.lastState?.username ?? '';
     const itemDefs = this.lastState?.itemDefinitions ?? {};
-    const inventory = this.lastState?.character?.inventory ?? {};
+    // Inventory comes from the frozen snapshot, not live state. The picker
+    // and qty buttons all reference this snapshot, so the tick can't move
+    // items out from under the user's selection. The server validates the
+    // offer at submission time (issue #342).
+    const inventory = this.tradeInventorySnapshot ?? {};
+
+    // Skip the re-render entirely when nothing the user can see has changed.
+    // Without this, every server tick wipes innerHTML and resets scroll, focus,
+    // etc., even when the active trade and the local selection are identical.
+    const renderKey = this.computeTradeRenderKey(trade);
+    if (renderKey === this.lastTradeRenderKey) return;
+    this.lastTradeRenderKey = renderKey;
 
     // If a trade was being viewed but is now gone (cancelled/confirmed), close.
     if (this.tradeActiveId && !trade) {
@@ -1709,6 +1748,30 @@ export class SocialScreen implements Screen {
     modal.innerHTML = html;
   }
 
+  /**
+   * Fingerprint of the trade state + local selection. Used to skip the
+   * tick-driven re-render when nothing has actually changed.
+   */
+  private computeTradeRenderKey(trade: TradeState | null): string {
+    const selStr = Array.from(this.tradeSelectedItems.entries())
+      .map(([id, qty]) => `${id}:${qty}`)
+      .sort()
+      .join(',');
+    if (!trade) {
+      return `new|${this.tradeTargetUsername ?? ''}|${selStr}`;
+    }
+    const offerStr = (items: TradeOfferItem[]): string =>
+      items.map(i => `${i.itemId}:${i.quantity}`).sort().join(',');
+    return [
+      trade.id,
+      trade.status,
+      trade.lastUpdatedBy,
+      offerStr(trade.initiator.items),
+      offerStr(trade.target?.items ?? []),
+      selStr,
+    ].join('|');
+  }
+
   dismissTradeModal(): void {
     if (this.tradeModalEl) {
       release(this.tradeModalEl);
@@ -1718,6 +1781,8 @@ export class SocialScreen implements Screen {
     this.tradeSelectedItems = new Map();
     this.tradeActiveId = null;
     this.tradeTargetUsername = null;
+    this.tradeInventorySnapshot = null;
+    this.lastTradeRenderKey = '';
   }
 
   // ── Gift Modal ────────────────────────────────────────────────

--- a/client/src/ui/ChatPopout.ts
+++ b/client/src/ui/ChatPopout.ts
@@ -150,8 +150,18 @@ export class ChatPopout {
     this.persistOpenState();
     requestAnimationFrame(() => {
       this.timelineEl.scrollTop = this.timelineEl.scrollHeight;
-      this.inputEl.focus();
+      // Mobile: don't grab focus on open — that pops the soft keyboard over
+      // the timeline, so the user can't read the messages they just opened.
+      if (!this.isMobile()) this.inputEl.focus();
     });
+  }
+
+  /** Open the popout and pre-fill the composer for a DM to `username`. */
+  openDm(username: string): void {
+    this.open();
+    this.channelSelect.value = 'dm';
+    this.dmInput.value = username;
+    this.dmInput.style.display = '';
   }
 
   close(): void {

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -23,7 +23,7 @@ export type PartyState = 'idle' | 'moving' | 'in_battle';
 export const RESULT_PAUSE = 600;      // ms to show victory/defeat before movement
 export const MOVE_DURATION = 400;     // ms for tile movement (client animation)
 export const RUN_AVAILABLE_ROUNDS = 5; // rounds before "Run" becomes available
-export const GAME_VERSION = '2026.05.11.1'; // Keep in sync with PATCH_NOTES in client
+export const GAME_VERSION = '2026.05.13.1'; // Keep in sync with PATCH_NOTES in client
 
 // --- Protocol types (server → client, client → server) ---
 


### PR DESCRIPTION
## Summary

Closes [#342](https://github.com/lucashutyler/idle-party-hexagogo/issues/342) and [#344](https://github.com/lucashutyler/idle-party-hexagogo/issues/344).

- **#342 — Trade scroll reset.** Trade picker now reads from an inventory snapshot frozen at modal open. `updateTradeModal` early-returns when the trade-state + selection fingerprint hasn't changed, so the per-second tick stops rebuilding the modal entirely — scroll, focus, and hover state all survive ticks for free. Server stays authoritative on submit.
- **#344a — Chat action on user popup.** `ChatPopout.openDm(username)` opens the pop-out pre-filled for a DM. `SocialScreen.startDm` now invokes a wired callback; `App.ts` connects it to the popout and lights up the Chat nav button.
- **#344b — Run hint on mobile.** Stopped setting `disabled` on the Run button — disabled `<button>`s swallow `click` on mobile, which was killing the locked-state hint tap. Visual state still uses `.combat-run-locked`.
- **#344c — Mobile chat autofocus.** `ChatPopout.open()` no longer calls `inputEl.focus()` on mobile, so the soft keyboard doesn't cover the timeline you just opened.
- **#344d — Future skills hidden.** Skill slot picker iterates `SKILL_TREES[className]` so future (locked) skills show as dimmed "Unlocks at Lv X" rows alongside unlocked picks. Click handler ignores locked rows.
- Bumped `GAME_VERSION` to `2026.05.13.1` with matching `PATCH_NOTES` entry. GameLoop will auto-broadcast the patch announcement to all sessions on next server start.

## Test plan

- [ ] Open a trade, scroll down in the picker, leave it alone for >2 seconds — scroll position holds
- [ ] Open a trade, +/- on items still re-renders the modal correctly
- [ ] Have the counterparty update their offer mid-modal — the offer cards update without disturbing your selection or scroll
- [ ] Trade still validates server-side if your inventory changes while the modal is open
- [ ] User popup → Chat opens the chat pop-out, channel select shows DM, target field is filled, nav button shows active
- [ ] On mobile, tap the locked Run button in combat — "Available after 5 rounds" hint shows briefly
- [ ] On mobile, open chat — soft keyboard does NOT pop up; tapping the input box brings it up
- [ ] Skill slot popup shows future skills as dimmed rows with "Unlocks at Lv X" tags; clicking a locked row does nothing
- [ ] All 132 tests pass (`npm run test`), `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)