### PR TITLE
Map: fix overlay markers + room-popup overflow

### DIFF
--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -1,5 +1,11 @@
 export const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.06.02.1',
+    notes: [
+      'Map: your party marker, movement path, hover outline, and other players\' flags now show up on rooms away from your starting area again — they were being hidden once you travelled out a bit.',
+    ],
+  },
+  {
     version: '2026.05.26.1',
     notes: [
       'Map is now rendered with WebGL — panning and zooming should feel substantially smoother on every device, especially mobile and larger maps. Idle map screens cost effectively zero performance now.',

--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -3,6 +3,7 @@ export const PATCH_NOTES: { version: string; notes: string[] }[] = [
     version: '2026.06.02.1',
     notes: [
       'Map: your party marker, movement path, hover outline, and other players\' flags now show up on rooms away from your starting area again — they were being hidden once you travelled out a bit.',
+      'Room popup: when a room is packed with players, the list of parties now scrolls inside the popup instead of growing past the screen — the close and action buttons always stay visible.',
     ],
   },
   {

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -1844,7 +1844,13 @@ html, body {
   pointer-events: none;
   transform-origin: 0 0;
   will-change: transform;
-  overflow: hidden;
+  /* Children are positioned at *world* coords and the overlay carries the
+   * camera transform. overflow must stay visible: clipping here happens in
+   * the overlay's untransformed local box (viewport-sized at the origin),
+   * which would hide any element whose world coords fall outside it — i.e.
+   * every tile beyond the starting area. #game-container's overflow:hidden
+   * clips the truly off-screen overflow instead. */
+  overflow: visible;
 }
 
 .three-map-party,

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -6245,8 +6245,11 @@ html, body {
 }
 .room-view-remote {
   width: min(360px, 90vw);
+  max-height: 90vh;
   padding: 16px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
 }
 .room-view-current {
   width: min(680px, 95vw);
@@ -6275,7 +6278,9 @@ html, body {
   display: flex;
   flex-direction: column;
   padding: 16px;
-  overflow-y: auto;
+  /* hidden (not auto) so the party list is the sole scroll region — keeps
+   * the header and action buttons pinned instead of scrolling them away. */
+  overflow: hidden;
   gap: 12px;
 }
 .room-view-close {
@@ -6343,6 +6348,12 @@ html, body {
   flex-direction: column;
   gap: 12px;
   margin: 8px 0;
+  /* The party list is the bounded scroll region: it shrinks (and scrolls
+   * internally) when there are too many players to fit, so the popup never
+   * grows past its container and shoves the action buttons off-screen. */
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 .room-party-other-label {
   font-size: 12px;

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -23,7 +23,7 @@ export type PartyState = 'idle' | 'moving' | 'in_battle';
 export const RESULT_PAUSE = 600;      // ms to show victory/defeat before movement
 export const MOVE_DURATION = 400;     // ms for tile movement (client animation)
 export const RUN_AVAILABLE_ROUNDS = 5; // rounds before "Run" becomes available
-export const GAME_VERSION = '2026.05.26.1'; // Keep in sync with PATCH_NOTES in client
+export const GAME_VERSION = '2026.06.02.1'; // Keep in sync with PATCH_NOTES in client
 
 // --- Protocol types (server → client, client → server) ---
 


### PR DESCRIPTION
## Summary
Two map-screen UI fixes from the WebGL map refactor.

**1. Overlay markers clipped on distant rooms**
- Party marker, movement path, hover outline, and other-player flags were invisible on rooms away from the starting area.
- Root cause: `.three-map-overlay` carries the camera transform, but its children are positioned at **world** pixel coordinates. With `overflow: hidden`, CSS clips children to the overlay's *untransformed* local box (viewport-sized, anchored at the local origin), so any marker whose world coords fall outside that box gets clipped before the camera transform places it on screen. Starting-area tiles sit near the world origin and survive; distant tiles get clipped away.
- Fix: set the overlay to `overflow: visible`. Off-screen clipping is already handled by `#game-container` (`overflow: hidden`, untransformed), so nothing bleeds into other UI.

**2. Room popup overflows the screen when a room is crowded**
- The remote-room popup had no height cap, and the current-room popup scrolled its whole content, so a room packed with players pushed the close/action buttons off-screen.
- Fix: cap the popup to the viewport and make `.room-view-parties` the bounded scroll region in both layouts (`flex: 0 1 auto; min-height: 0; overflow-y: auto`), keeping the header and action buttons pinned and visible.

## Changes
- `client/src/styles/pixel-theme.css` — `.three-map-overlay` → `overflow: visible`; room-popup scroll containment (`.room-view-remote` viewport cap, `.room-view-content` overflow, `.room-view-parties` scroll region).
- `client/src/screens/PatchNotes.ts` — patch note `2026.06.02.1` (two bullets).
- `shared/src/systems/BattleTypes.ts` — bump `GAME_VERSION` to match.

## Test plan
- [ ] Move your party several zones out from the starting island and confirm the party marker, path preview, hover outline, and other-player flags all render on distant rooms (and still render near the start).
- [ ] Pan/zoom and confirm markers stay pinned to their rooms and nothing bleeds outside the map area.
- [ ] Open the room popup on a room crowded with players (dev bots cluster in the seeded dev zones) and confirm the party list scrolls inside the popup while the close and action buttons stay on-screen — both for your current room and a remote room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)