### PR TITLE
Fix monster + zone artwork loading (by id, not slugified name)

### DIFF
--- a/client/src/screens/CombatScreen.ts
+++ b/client/src/screens/CombatScreen.ts
@@ -11,9 +11,15 @@ function slugify(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'unknown';
 }
 
-/** Build the chain of artwork URLs to try for a monster, ending in placehold.co. */
-function monsterArtSrc(name: string): { real: string; fallback: string } {
-  return { real: artworkUrl('monster', slugify(name)), fallback: placeholderUrl(name, { w: 160, h: 160 }) };
+/**
+ * Build the chain of artwork URLs to try for a monster, ending in placehold.co.
+ * Art is keyed by the monster's definition id (matching the admin upload, which
+ * saves to `/monster-artwork/{id}.png`); falls back to a name slug for any older
+ * art dropped in by name.
+ */
+function monsterArtSrc(monster: { id?: string; name: string }): { real: string; fallback: string } {
+  const key = monster.id || slugify(monster.name);
+  return { real: artworkUrl('monster', key), fallback: placeholderUrl(monster.name, { w: 160, h: 160 }) };
 }
 
 /** Build artwork URLs for a class. */
@@ -300,7 +306,7 @@ export class CombatScreen implements Screen {
           card.classList.toggle('stunned', !!(m.stunTurns && m.stunTurns > 0));
           const img = card.querySelector('.combat-card-img') as HTMLImageElement | null;
           if (img) {
-            const { real, fallback } = monsterArtSrc(m.name);
+            const { real, fallback } = monsterArtSrc(m);
             if (img.dataset.src !== real) {
               img.dataset.src = real;
               img.dataset.fb = '0';
@@ -409,17 +415,21 @@ export class CombatScreen implements Screen {
   private updateCombatBackground(state: ServerStateMessage): void {
     const bg = this.container.querySelector('.combat-stage-bg') as HTMLElement | null;
     if (!bg) return;
-    const zone = (state.party?.col != null && state.party?.row != null) ? state.zoneName : '';
-    const zoneId = state.social?.party?.id ? state.social.party.id : zone;
-    // Tile-specific override: combat-bg-artwork/{zoneId}-{col}-{row}.png; zone default: combat-bg-artwork/{zoneId}.png
-    const tileSrc = state.party
-      ? `/combat-bg-artwork/${slugify(zone)}-${state.party.col}-${state.party.row}.png`
-      : '';
-    const zoneSrc = `/combat-bg-artwork/${slugify(zone || zoneId)}.png`;
-    const fallback = placeholderUrl(zone || 'Combat', { w: 800, h: 400, bg: '1a1a2e', fg: '666' });
-    const layered = tileSrc
-      ? `url('${tileSrc}'), url('${zoneSrc}'), url('${fallback}')`
-      : `url('${zoneSrc}'), url('${fallback}')`;
+    const zoneName = (state.party?.col != null && state.party?.row != null) ? (state.zoneName ?? '') : '';
+    // The zone id is the current room's `zone` tag — admin art is keyed by it
+    // (matching `/zone-artwork/{id}` and `/combat-bg-artwork/{id}` uploads),
+    // not by a slugified display name.
+    const tile = state.party ? this.worldCache.getTile(state.party.col, state.party.row) : null;
+    const zoneId = tile?.zone ?? '';
+    const enc = encodeURIComponent;
+    // Layered background, first found wins:
+    //   per-room combat bg → zone combat bg → zone artwork (admin upload) → placeholder.
+    const layers: string[] = [];
+    if (state.party && zoneId) layers.push(`/combat-bg-artwork/${enc(zoneId)}-${state.party.col}-${state.party.row}.png`);
+    if (zoneId) layers.push(`/combat-bg-artwork/${enc(zoneId)}.png`);
+    if (zoneId) layers.push(`/zone-artwork/${enc(zoneId)}.png`);
+    layers.push(placeholderUrl(zoneName || 'Combat', { w: 800, h: 400, bg: '1a1a2e', fg: '666' }));
+    const layered = layers.map(u => `url('${u}')`).join(', ');
     if (bg.dataset.bgKey !== layered) {
       bg.style.backgroundImage = layered;
       bg.dataset.bgKey = layered;
@@ -507,12 +517,12 @@ export class CombatScreen implements Screen {
     }
   }
 
-  private showMonsterPopup(monster: { name: string; currentHp: number; maxHp: number; description?: string }, _anchor: HTMLElement): void {
+  private showMonsterPopup(monster: { id?: string; name: string; currentHp: number; maxHp: number; description?: string }, _anchor: HTMLElement): void {
     const existing = document.querySelector('.monster-popup-overlay') as HTMLElement | null;
     if (existing) { release(existing); existing.remove(); }
     const overlay = document.createElement('div');
     overlay.className = 'monster-popup-overlay';
-    const { real, fallback } = monsterArtSrc(monster.name);
+    const { real, fallback } = monsterArtSrc(monster);
     const description = monster.description?.trim();
     const descriptionHtml = description
       ? `<div class="monster-popup-description">${this.escapeHtml(description)}</div>`

--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -1,5 +1,12 @@
 export const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.06.21.2',
+    notes: [
+      'Custom monster artwork now shows up in battle — art uploaded in the admin was being matched by name instead of the monster\'s saved id, so it never appeared for newer monsters.',
+      'Combat backgrounds now use a zone\'s uploaded artwork (matched by the zone\'s id), with per-room overrides still taking priority.',
+    ],
+  },
+  {
     version: '2026.06.14.1',
     notes: [
       'Dungeons are open for business! Stand on a dungeon room and tap "Enter" — your whole party dives in together and fights through its floors.',

--- a/server/src/game/PartyBattleManager.ts
+++ b/server/src/game/PartyBattleManager.ts
@@ -392,6 +392,7 @@ export class PartyBattleManager {
         stunTurns: p.stunTurns > 0 ? p.stunTurns : undefined,
       })),
       monsters: combat.monsters.map(m => ({
+        id: m.id,
         name: m.name,
         currentHp: m.currentHp,
         maxHp: m.maxHp,

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -24,7 +24,7 @@ export type PartyState = 'idle' | 'moving' | 'in_battle';
 export const RESULT_PAUSE = 600;      // ms to show victory/defeat before movement
 export const MOVE_DURATION = 400;     // ms for tile movement (client animation)
 export const RUN_AVAILABLE_ROUNDS = 5; // rounds before "Run" becomes available
-export const GAME_VERSION = '2026.06.14.1'; // Keep in sync with PATCH_NOTES in client
+export const GAME_VERSION = '2026.06.21.2'; // Keep in sync with PATCH_NOTES in client
 
 // --- Protocol types (server → client, client → server) ---
 
@@ -50,6 +50,8 @@ export interface ClientPlayerCombatant {
 }
 
 export interface ClientMonsterState {
+  /** Monster definition id (its artwork key). Same for all instances of a type. */
+  id: string;
   name: string;
   currentHp: number;
   maxHp: number;


### PR DESCRIPTION
**Unrelated to the multi-map PR (#351)** — a pre-existing artwork bug found while testing uploads.

## Problem
The admin artwork uploader saves files under the entity's **GUID** (`/monster-artwork/{id}.png`, `/zone-artwork/{id}.png`), but the combat screen loaded art by a **slugified display name** (`/monster-artwork/puffly-cloud.png`). So uploaded art only resolved for seed entities whose id happens to equal their slug (`goblin`) and 404'd for any admin-created monster/zone (which get `crypto.randomUUID()` ids).

## Fix
- **Monsters**: the combat monster instance already carries its definition id (`MonsterInstance.id = def.id`), it just wasn't sent to the client. Added `id` to `ClientMonsterState`, populate it in `PartyBattleManager.getBattleState`, and `CombatScreen` now loads `/monster-artwork/{id}.png` (with a name-slug fallback for any older art).
- **Combat backgrounds**: now derive the real zone id from the current room's `zone` tag (the previous code keyed off a slugified name and a `zoneId` that was actually the *party* id — a latent bug). The zone's admin-uploaded artwork (`/zone-artwork/{zoneId}.png`) is now used as a combat-background layer, so ZonesTab uploads finally appear. Per-room (`/combat-bg-artwork/{zoneId}-{col}-{row}.png`) and per-zone combat-bg overrides still take priority.

Seed entities are unaffected (their id equals their slug). No protocol change for zones (the client derives the id from the cached world tile); monsters get one new field.

## Verification
520 tests pass, typecheck + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)