### PR TITLE
Replace pixel fonts with a painted-fantasy type pairing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,10 +14,6 @@
     <meta name="apple-mobile-web-app-title" content="Idle Party" />
   </head>
   <body>
-    <div id="splash">
-      <img class="splash-logo-img" src="/logo-artwork/idle-party.png" alt="Idle Party RPG"
-           onerror="if(this.dataset.fb!=='1'){this.dataset.fb='1';this.src='https://placehold.co/520x180/4a5568/f5c842/png?text=Idle+Party+RPG';}else{this.style.display='none';}" />
-    </div>
     <div id="app">
       <div id="screen-container">
         <div id="screen-offline" class="screen"></div>

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -48,27 +48,6 @@ export class App {
     this.xpBarEl = document.getElementById('persistent-xp-bar')!;
     this.xpBarEl.style.display = 'none';
 
-    // Splash overlay: minimum 2-second hold, then fade once the window has
-    // finished loading. Whichever takes longer wins — fast loads still see
-    // a full 2 seconds of brand frame; slow loads get held until ready.
-    const startedAt = Date.now();
-    const MIN_HOLD_MS = 2000;
-    const dismissWhenReady = () => {
-      const elapsed = Date.now() - startedAt;
-      const remaining = Math.max(0, MIN_HOLD_MS - elapsed);
-      setTimeout(() => {
-        const splash = document.getElementById('splash');
-        if (!splash || splash.classList.contains('hidden')) return;
-        splash.classList.add('hidden');
-        setTimeout(() => splash.remove(), 600);
-      }, remaining);
-    };
-    if (document.readyState === 'complete') {
-      dismissWhenReady();
-    } else {
-      window.addEventListener('load', dismissWhenReady, { once: true });
-    }
-
     // Offline screen
     this.offlineScreen = new OfflineScreen('screen-offline', () => {
       this.retryConnection();

--- a/client/src/screens/PatchNotes.ts
+++ b/client/src/screens/PatchNotes.ts
@@ -1,5 +1,13 @@
 export const PATCH_NOTES: { version: string; notes: string[] }[] = [
   {
+    version: '2026.08.14.1',
+    notes: [
+      'The game now opens straight into play — the loading screen is gone.',
+      'Text throughout the game has a new look. The old pixel lettering has been replaced with a fantasy typeface for headings and a cleaner one for everything else, so smaller text is much easier to read.',
+      'The sign-in screen has been redesigned to match, with a larger title and a bigger, easier-to-tap email field.',
+    ],
+  },
+  {
     version: '2026.07.28.1',
     notes: [
       'You can now dismiss individual notifications or clear your whole notification list — cleared notifications are gone for good, not just marked as read.',

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -1,17 +1,25 @@
 /*
- * Font choice: Silkscreen for body/UI (clear digits — no 6/G confusion that
- * Press Start 2P had), Pixelify Sans for display headings (a touch warmer
- * and easier to read at large sizes). Both are pixel-style and feel like
- * a game, not a web app. If you want to swap to something else, change the
- * --pixel-font and --display-font variables and adjust the @import accordingly.
+ * Font choice: Cinzel for display (carved Roman caps — the Trajan/Friz
+ * Quadrata lineage WoW uses for headings), Alegreya Sans for body/UI
+ * (humanist, holds up at small sizes, good numerals). The pixel faces
+ * (Silkscreen / Pixelify Sans) are gone — they fight the painted 2D art
+ * direction. To swap, change --ui-font and --display-font and adjust the
+ * @import accordingly.
+ *
+ * TODO: self-host these as .woff2. The @import is render-blocking and the
+ * PWA can't cache a third-party origin, so offline loads lose the typeface.
  */
-@import url('https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&family=Pixelify+Sans:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Alegreya+Sans:wght@400;500;700&display=swap');
 
 /* ── CSS Custom Properties ───────────────────────────────── */
 
 :root {
-  --pixel-font: 'Silkscreen', 'Press Start 2P', monospace;
-  --display-font: 'Pixelify Sans', 'Silkscreen', monospace;
+  /* --pixel-font is kept as an alias so the ~200 existing references keep
+     working; it now resolves to the UI face, not a pixel one. New code
+     should use --ui-font. */
+  --ui-font: 'Alegreya Sans', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --pixel-font: var(--ui-font);
+  --display-font: 'Cinzel', Georgia, 'Times New Roman', serif;
   --nav-height: 64px;
   --xpbar-height: 12px;
 
@@ -65,10 +73,11 @@
   }
 }
 
-/* Don't use bold anywhere — pixel-style fonts get muddy when bolded. To
-   emphasize, brighten or dim the color instead. */
+/* Bold is usable again now the pixel faces are gone — it only got muddy
+   because bitmap-style fonts smear when bolded. Emphasis still brightens
+   the color, but the weight now carries too. */
 b, strong {
-  font-weight: normal;
+  font-weight: 700;
   color: var(--text-primary);
 }
 
@@ -84,11 +93,11 @@ html, body {
   width: 100%;
   height: 100%;
   overflow: hidden;
-  font-family: var(--pixel-font);
+  font-family: var(--ui-font);
   color: var(--text-primary);
   background-color: var(--bg-dark);
-  -webkit-font-smoothing: none;
-  -moz-osx-font-smoothing: unset;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 #app {
@@ -117,7 +126,6 @@ html, body {
   display: flex;
   flex-direction: column;
 }
-
 /* ── Pixel Panel (reusable) ──────────────────────────────── */
 
 .pixel-panel {
@@ -665,7 +673,7 @@ html, body {
   background: var(--bg-surface);
   border: 2px solid var(--border-pixel);
   color: var(--accent-green);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--ui-font);
   font-size: 11px;
   padding: 4px 12px;
   cursor: pointer;
@@ -1727,7 +1735,7 @@ html, body {
   background: transparent;
   border: 1px solid var(--text-dim);
   color: var(--text-dim);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--ui-font);
   font-size: 8px;
   padding: 3px 5px;
   cursor: pointer;
@@ -1786,7 +1794,7 @@ html, body {
 }
 
 .items-modal-btn {
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--ui-font);
   font-size: 11px;
   padding: 6px 10px;
   border: 2px solid var(--border-pixel);
@@ -1985,7 +1993,7 @@ html, body {
 .three-map-badge {
   background: #4a90d9;
   color: #fff;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--ui-font);
   font-size: 10px;
   padding: 2px 4px;
   border-radius: 2px;
@@ -2690,10 +2698,16 @@ html, body {
 }
 
 .login-title {
-  font-family: var(--pixel-font);
-  font-size: 19px;
+  font-family: var(--display-font);
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.15;
+  text-wrap: balance;
   color: var(--accent-gold);
-  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.5);
+  /* Soft drop shadow rather than the old hard 2px pixel offset — Cinzel has
+     real curves and a stepped shadow reads as an artifact against them. */
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.7);
   text-align: center;
 }
 
@@ -2716,9 +2730,11 @@ html, body {
 
 .login-input {
   width: 100%;
+  /* 16px is the floor that stops iOS Safari zooming the viewport on focus. */
+  font-size: 16px;
+  min-height: 44px;
   padding: 10px 12px;
-  font-family: var(--pixel-font);
-  font-size: 13px;
+  font-family: var(--ui-font);
   color: var(--text-primary);
   background: var(--bg-input);
   border: 2px solid var(--border-pixel);
@@ -2735,9 +2751,13 @@ html, body {
 
 .login-button {
   width: 100%;
+  min-height: 44px;
   padding: 10px 12px;
-  font-family: var(--pixel-font);
-  font-size: 13px;
+  font-family: var(--ui-font);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--bg-dark);
   background: var(--accent-gold);
   border: 2px solid var(--accent-gold);
@@ -4917,7 +4937,7 @@ html, body {
   width: 90vw;
   max-height: 85vh;
   overflow-y: auto;
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 11px;
   color: var(--text-primary, #eee);
   padding: 16px;
@@ -4944,7 +4964,7 @@ html, body {
 
 .admin-modal .admin-form input,
 .admin-modal .admin-form select {
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 11px;
   background: var(--bg-input, #0d1b2a);
   color: var(--text-primary, #eee);
@@ -4967,7 +4987,7 @@ html, body {
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 11px;
   color: var(--text-primary, #eee);
 }
@@ -4984,7 +5004,7 @@ html, body {
 .admin-encounter-modal-header input[type="text"] {
   flex: 1;
   min-width: 120px;
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 11px;
   padding: 4px 6px;
   background: var(--bg-panel, #222);
@@ -4993,7 +5013,7 @@ html, body {
 }
 
 .admin-encounter-modal-header select {
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 11px;
   padding: 4px 6px;
   background: var(--bg-panel, #222);
@@ -5032,7 +5052,7 @@ html, body {
 
 .enc-pool-row select,
 .enc-pool-row input {
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 10px;
   padding: 3px 4px;
   background: var(--bg-panel, #222);
@@ -5059,7 +5079,7 @@ html, body {
 }
 
 .enc-room-max input {
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 10px;
   padding: 3px 4px;
   background: var(--bg-panel, #222);
@@ -5095,7 +5115,7 @@ html, body {
 }
 
 .enc-grid-cell select {
-  font-family: var(--pixel-font, 'Press Start 2P', monospace);
+  font-family: var(--ui-font);
   font-size: 10px;
   padding: 3px 4px;
   background: var(--bg-darker, #1a1a2e);
@@ -5589,36 +5609,11 @@ html, body {
 
 /* =====================================================================
    UI OVERHAUL — May 2026
-   New styles added below for: splash, persistent XP bar, restyled nav,
+   New styles added below for: persistent XP bar, restyled nav,
    chat popout, combat cards + monster popup + combat backgrounds,
    room view (full-screen current + smaller remote), CharItems screen,
    inventory grouping headers, leaderboard polish.
    ===================================================================== */
-
-/* ── Splash Screen ───────────────────────────────────────── */
-#splash {
-  position: fixed;
-  inset: 0;
-  background: #4a5568; /* slate gray */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  transition: opacity 500ms ease-out;
-}
-#splash.hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-.splash-logo-img {
-  max-width: min(520px, 80vw);
-  max-height: 60vh;
-  width: auto;
-  height: auto;
-  display: block;
-  image-rendering: pixelated;
-  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.45));
-}
 
 /* ── Persistent XP Bar (above bottom nav) ────────────────── */
 #persistent-xp-bar {

--- a/shared/src/systems/BattleTypes.ts
+++ b/shared/src/systems/BattleTypes.ts
@@ -25,7 +25,7 @@ export type PartyState = 'idle' | 'moving' | 'in_battle';
 export const RESULT_PAUSE = 600;      // ms to show victory/defeat before movement
 export const MOVE_DURATION = 400;     // ms for tile movement (client animation)
 export const RUN_AVAILABLE_ROUNDS = 5; // rounds before "Run" becomes available
-export const GAME_VERSION = '2026.07.28.1'; // Keep in sync with PATCH_NOTES in client
+export const GAME_VERSION = '2026.08.14.1'; // Keep in sync with PATCH_NOTES in client
 
 // --- Protocol types (server → client, client → server) ---
 


### PR DESCRIPTION
The pixel faces fight the 2D painted art direction the game is moving toward, so they're removed rather than retuned.

## Type
- Silkscreen / Pixelify Sans → **Cinzel** (display) + **Alegreya Sans** (UI)
- `-webkit-font-smoothing: none` → `antialiased`. The old value made proportional type render badly.
- Dropped the `b, strong { font-weight: normal }` reset — it existed because bitmap-style faces smear when bolded, which no longer applies.
- Removed 12 hardcoded `'Press Start 2P'` references. That font hasn't been imported since the May overhaul, so those rules were silently falling back to the browser default monospace.

`--pixel-font` is kept as an alias of the new `--ui-font` so the ~200 existing call sites keep working. New code should use `--ui-font`.

## Also in here
- **Splash screen removed** — markup, CSS, and the 2s minimum-hold logic in `App.ts`.
- **Login screen restyled** to match: display-face title, and a 16px / 44px email field so iOS stops zooming the viewport on focus.

## Expect it to look unfinished
358 font sizes were tuned for a bitmap face at 8–14px. Proportional type at those sizes reads small and loose in places. Retuning them onto the (currently dead) `--fs-*` scale is separate work.

## Follow-up
Self-host both faces as `.woff2`. The Google Fonts `@import` is render-blocking, and a third-party origin can't be cached by the service worker, so offline PWA loads lose the typeface.

## Testing
`tsc --build` clean, 252 tests pass.

## Note
This and #skill-icons both add a patch-notes entry dated today (`.1` and `.2`). Whichever merges second needs renumbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)