### PR TITLE
Give ScreenManager a navigation stack and a shared back header

### DIFF
--- a/client/src/screens/ScreenManager.ts
+++ b/client/src/screens/ScreenManager.ts
@@ -1,51 +1,211 @@
+/**
+ * Screen navigation.
+ *
+ * Two axes, deliberately separate:
+ *
+ * - **Roots** are the top-level destinations owned by the bottom nav. Switching
+ *   root (`switchTo`) discards any drill-down and starts a fresh stack. There is
+ *   always exactly one root.
+ * - **Pushes** are drill-downs on top of the current root (`push`). They stack,
+ *   they get a back header, and they are popped by the back button — the app's
+ *   own, the browser's, and Android's hardware key, which are all the same
+ *   thing via `popstate`.
+ *
+ * This is the iOS/Android tab-bar-plus-stack model. It exists so the game reads
+ * as a mobile app rather than a set of long scrolling pages: content that used
+ * to be stacked into one tall screen becomes a push instead.
+ */
+
 export interface Screen {
-  onActivate(): void;
+  /**
+   * Called when the screen becomes visible. `params` carries whatever `push`
+   * was given — screens that take no parameters can keep declaring
+   * `onActivate(): void`, which stays assignable.
+   */
+  onActivate(params?: unknown): void;
   onDeactivate(): void;
 }
 
 interface RegisteredScreen {
   element: HTMLElement;
   screen: Screen;
+  /** Header title used when this screen is pushed. Roots never show a header. */
+  title?: string;
+}
+
+interface StackEntry {
+  id: string;
+  params?: unknown;
+}
+
+/** Marks our own history entries so we ignore states pushed by anything else. */
+interface NavHistoryState {
+  ipDepth: number;
+}
+
+function isNavState(value: unknown): value is NavHistoryState {
+  return typeof value === 'object' && value !== null && typeof (value as NavHistoryState).ipDepth === 'number';
 }
 
 export class ScreenManager {
   private screens = new Map<string, RegisteredScreen>();
-  private activeScreenId: string | null = null;
+  private stack: StackEntry[] = [];
+  private headerEl: HTMLElement | null = null;
+  private titleEl: HTMLElement | null = null;
+  private stackListeners = new Set<(depth: number) => void>();
+  /** Set while we drive history ourselves, so our own popstate is a no-op. */
+  private suppressPopstate = false;
 
-  register(id: string, element: HTMLElement, screen: Screen): void {
-    this.screens.set(id, { element, screen });
+  constructor() {
+    this.mountHeader();
+    window.addEventListener('popstate', (e) => this.handlePopstate(e));
   }
 
+  register(id: string, element: HTMLElement, screen: Screen, title?: string): void {
+    this.screens.set(id, { element, screen, title });
+  }
+
+  /**
+   * Switch to a top-level destination, discarding any drill-down. This is what
+   * a bottom-nav tab does. Re-selecting the current root while deep in a stack
+   * pops back to it — matching how tab bars behave everywhere else.
+   */
   switchTo(id: string): void {
-    if (this.activeScreenId === id) return;
+    if (this.stack.length === 1 && this.stack[0].id === id) return;
+    this.stack = [{ id }];
+    this.replaceHistory();
+    this.applyTop();
+  }
 
-    // Deactivate the tracked active screen
-    const current = this.activeScreenId ? this.screens.get(this.activeScreenId) : undefined;
-    if (current) {
-      current.element.classList.remove('active');
-      current.screen.onDeactivate();
-    }
+  /** Drill down. The current screen stays mounted underneath, deactivated. */
+  push(id: string, params?: unknown): void {
+    if (!this.screens.has(id)) return;
+    this.stack.push({ id, params });
+    this.suppressPopstate = true;
+    history.pushState({ ipDepth: this.stack.length } satisfies NavHistoryState, '');
+    this.suppressPopstate = false;
+    this.applyTop();
+  }
 
-    // Remove stale active classes from all other screens (e.g. HTML-defined defaults)
+  /**
+   * Go back one level. Returns false at the root, so callers can fall through
+   * to whatever "back" means there (usually nothing).
+   */
+  pop(): boolean {
+    if (this.stack.length <= 1) return false;
+    this.stack.pop();
+    this.suppressPopstate = true;
+    history.back();
+    this.suppressPopstate = false;
+    this.applyTop();
+    return true;
+  }
+
+  canGoBack(): boolean {
+    return this.stack.length > 1;
+  }
+
+  /** Id of the visible screen, whether it is a root or a pushed one. */
+  getActiveScreenId(): string | null {
+    return this.stack.length ? this.stack[this.stack.length - 1].id : null;
+  }
+
+  /** Id of the current root — what the bottom nav should show as selected. */
+  getRootScreenId(): string | null {
+    return this.stack.length ? this.stack[0].id : null;
+  }
+
+  /** Notified on every depth change, so the nav can hide itself in a drill-down. */
+  onStackChange(cb: (depth: number) => void): () => void {
+    this.stackListeners.add(cb);
+    return () => this.stackListeners.delete(cb);
+  }
+
+  // ── internals ─────────────────────────────────────────────
+
+  /**
+   * One shared header rather than one per screen: a back affordance that is
+   * implemented twelve times is a back affordance that behaves twelve ways.
+   * It only appears at depth > 1 — roots are already identified by the nav
+   * tab, and a redundant title bar costs vertical space the screens need.
+   */
+  private mountHeader(): void {
+    const container = document.getElementById('screen-container');
+    if (!container || !container.parentElement) return;
+
+    const header = document.createElement('header');
+    header.id = 'screen-header';
+    header.hidden = true;
+
+    const back = document.createElement('button');
+    back.type = 'button';
+    back.className = 'screen-header-back';
+    back.setAttribute('aria-label', 'Go back');
+    back.innerHTML = '<span aria-hidden="true">‹</span>';
+    back.addEventListener('click', () => this.pop());
+
+    const title = document.createElement('h1');
+    title.className = 'screen-header-title';
+
+    header.append(back, title);
+    container.parentElement.insertBefore(header, container);
+
+    this.headerEl = header;
+    this.titleEl = title;
+  }
+
+  private handlePopstate(e: PopStateEvent): void {
+    if (this.suppressPopstate) return;
+    // Ignore history entries we did not create.
+    if (!isNavState(e.state) && this.stack.length <= 1) return;
+
+    const targetDepth = isNavState(e.state) ? e.state.ipDepth : 1;
+    if (targetDepth >= this.stack.length) return;
+
+    this.stack.length = Math.max(1, targetDepth);
+    this.applyTop();
+  }
+
+  private replaceHistory(): void {
+    this.suppressPopstate = true;
+    history.replaceState({ ipDepth: 1 } satisfies NavHistoryState, '');
+    this.suppressPopstate = false;
+  }
+
+  /** Render whatever is on top of the stack and deactivate everything else. */
+  private applyTop(): void {
+    const top = this.stack[this.stack.length - 1];
+    if (!top) return;
+
     for (const [screenId, registered] of this.screens) {
-      if (screenId !== id) {
+      if (screenId === top.id) continue;
+      if (registered.element.classList.contains('active')) {
+        registered.element.classList.remove('active');
+        registered.screen.onDeactivate();
+      } else {
+        // Clears stale `active` set in the HTML before any switch happened.
         registered.element.classList.remove('active');
       }
     }
 
-    const next = this.screens.get(id);
+    const next = this.screens.get(top.id);
     if (next) {
       next.element.classList.add('active');
-      next.screen.onActivate();
+      next.screen.onActivate(top.params);
     }
 
-    this.activeScreenId = id;
-    // Expose the active screen on the body so global CSS can adapt
-    // (e.g. mobile chat sheet replaces the combat log instead of stacking).
-    document.body.dataset.activeScreen = id;
+    this.updateHeader(next?.title);
+    document.body.dataset.activeScreen = top.id;
+    document.body.dataset.navDepth = String(this.stack.length);
+
+    for (const cb of this.stackListeners) cb(this.stack.length);
   }
 
-  getActiveScreenId(): string | null {
-    return this.activeScreenId;
+  private updateHeader(title?: string): void {
+    if (!this.headerEl || !this.titleEl) return;
+    const deep = this.stack.length > 1;
+    this.headerEl.hidden = !deep;
+    // textContent, not innerHTML — titles can carry player-supplied text.
+    this.titleEl.textContent = deep ? (title ?? '') : '';
   }
 }

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -118,6 +118,79 @@ html, body {
   flex-direction: column;
 }
 
+/* ── Screen Header (drill-down back bar) ─────────────────── */
+
+/*
+ * One shared header owned by ScreenManager, shown only at nav depth > 1.
+ * Root screens are already identified by the bottom nav, so they get no
+ * title bar — vertical space is the scarce resource on a phone.
+ */
+#screen-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 48px;
+  padding: 0 8px;
+  background: var(--bg-panel);
+  border-bottom: 2px solid var(--border-pixel);
+  /* Notched phones: this is the topmost chrome once a screen is pushed. */
+  padding-top: env(safe-area-inset-top, 0px);
+}
+
+#screen-header[hidden] {
+  display: none;
+}
+
+.screen-header-back {
+  /* 44px minimum target — see WCAG 2.5.8. */
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--pixel-font);
+  font-size: 32px;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.screen-header-back:active {
+  color: var(--accent-gold);
+}
+
+.screen-header-title {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-family: var(--display-font);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * Designated scroll region. `.screen` is already overflow:hidden, so screens
+ * never scroll as a whole — content that must scroll opts in explicitly by
+ * wrapping in this class. That is the mechanism behind "limited scrolling":
+ * a list scrolls, a screen does not.
+ */
+.screen-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* ── Pixel Panel (reusable) ──────────────────────────────── */
 
 .pixel-panel {

--- a/client/tests/ScreenManager.test.ts
+++ b/client/tests/ScreenManager.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ScreenManager, type Screen } from '../src/screens/ScreenManager';
+
+/** Records activate/deactivate order so tests can assert on lifecycle, not just classes. */
+class FakeScreen implements Screen {
+  activations: unknown[] = [];
+  deactivations = 0;
+
+  onActivate(params?: unknown): void {
+    this.activations.push(params);
+  }
+
+  onDeactivate(): void {
+    this.deactivations += 1;
+  }
+}
+
+function setupDom(): void {
+  document.body.innerHTML = `
+    <div id="app">
+      <div id="screen-container">
+        <div id="screen-a" class="screen"></div>
+        <div id="screen-b" class="screen"></div>
+        <div id="screen-c" class="screen"></div>
+      </div>
+    </div>
+  `;
+  delete document.body.dataset.activeScreen;
+  delete document.body.dataset.navDepth;
+}
+
+function build(): { mgr: ScreenManager; a: FakeScreen; b: FakeScreen; c: FakeScreen } {
+  const mgr = new ScreenManager();
+  const a = new FakeScreen();
+  const b = new FakeScreen();
+  const c = new FakeScreen();
+  mgr.register('a', document.getElementById('screen-a')!, a);
+  mgr.register('b', document.getElementById('screen-b')!, b, 'Screen B');
+  mgr.register('c', document.getElementById('screen-c')!, c, 'Screen C');
+  return { mgr, a, b, c };
+}
+
+const header = () => document.getElementById('screen-header')!;
+const headerTitle = () => header().querySelector('.screen-header-title')!;
+
+describe('ScreenManager', () => {
+  beforeEach(() => {
+    setupDom();
+    history.replaceState(null, '');
+  });
+
+  describe('roots', () => {
+    it('activates the screen it switches to', () => {
+      const { mgr, a } = build();
+      mgr.switchTo('a');
+      expect(a.activations).toHaveLength(1);
+      expect(document.getElementById('screen-a')!.classList.contains('active')).toBe(true);
+      expect(document.body.dataset.activeScreen).toBe('a');
+    });
+
+    it('deactivates the previous root when switching', () => {
+      const { mgr, a, b } = build();
+      mgr.switchTo('a');
+      mgr.switchTo('b');
+      expect(a.deactivations).toBe(1);
+      expect(document.getElementById('screen-a')!.classList.contains('active')).toBe(false);
+      expect(b.activations).toHaveLength(1);
+    });
+
+    it('is a no-op when switching to the already-active root', () => {
+      const { mgr, a } = build();
+      mgr.switchTo('a');
+      mgr.switchTo('a');
+      expect(a.activations).toHaveLength(1);
+      expect(a.deactivations).toBe(0);
+    });
+
+    it('starts at depth 1 with no back available', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      expect(mgr.canGoBack()).toBe(false);
+      expect(document.body.dataset.navDepth).toBe('1');
+    });
+  });
+
+  describe('push and pop', () => {
+    it('pushing keeps the root as the reported root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      expect(mgr.getRootScreenId()).toBe('a');
+      expect(mgr.getActiveScreenId()).toBe('b');
+      expect(mgr.canGoBack()).toBe(true);
+      expect(document.body.dataset.navDepth).toBe('2');
+    });
+
+    it('passes params through to onActivate', () => {
+      const { mgr, b } = build();
+      mgr.switchTo('a');
+      mgr.push('b', { slot: 'chest' });
+      expect(b.activations).toEqual([{ slot: 'chest' }]);
+    });
+
+    it('pops back to the screen underneath and reactivates it', () => {
+      const { mgr, a, b } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      expect(mgr.pop()).toBe(true);
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(a.activations).toHaveLength(2);
+      expect(b.deactivations).toBe(1);
+    });
+
+    it('refuses to pop at the root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      expect(mgr.pop()).toBe(false);
+      expect(mgr.getActiveScreenId()).toBe('a');
+    });
+
+    it('stacks more than one level deep', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.push('c');
+      expect(document.body.dataset.navDepth).toBe('3');
+      mgr.pop();
+      expect(mgr.getActiveScreenId()).toBe('b');
+      mgr.pop();
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(mgr.canGoBack()).toBe(false);
+    });
+
+    it('discards the drill-down when a new root is selected', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.push('c');
+      mgr.switchTo('a');
+      expect(mgr.canGoBack()).toBe(false);
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(document.body.dataset.navDepth).toBe('1');
+    });
+
+    it('ignores a push to an unregistered screen', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('nope');
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(mgr.canGoBack()).toBe(false);
+    });
+  });
+
+  describe('header', () => {
+    it('stays hidden at the root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      expect(header().hidden).toBe(true);
+    });
+
+    it('appears with the pushed screen title', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      expect(header().hidden).toBe(false);
+      expect(headerTitle().textContent).toBe('Screen B');
+    });
+
+    it('hides again after popping back to the root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.pop();
+      expect(header().hidden).toBe(true);
+      expect(headerTitle().textContent).toBe('');
+    });
+
+    it('sets the title as text, never as markup', () => {
+      const { mgr } = build();
+      mgr.register('x', document.getElementById('screen-c')!, new FakeScreen(), '<img src=x onerror=alert(1)>');
+      mgr.switchTo('a');
+      mgr.push('x');
+      expect(headerTitle().querySelector('img')).toBeNull();
+      expect(headerTitle().textContent).toBe('<img src=x onerror=alert(1)>');
+    });
+
+    it('has an accessible back control', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      const back = header().querySelector('.screen-header-back')!;
+      expect(back.getAttribute('aria-label')).toBe('Go back');
+    });
+
+    it('pops when the back control is clicked', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      (header().querySelector('.screen-header-back') as HTMLElement).click();
+      expect(mgr.getActiveScreenId()).toBe('a');
+    });
+  });
+
+  describe('stack listeners', () => {
+    it('reports each depth change and stops after unsubscribe', () => {
+      const { mgr } = build();
+      const depths: number[] = [];
+      const off = mgr.onStackChange((d) => depths.push(d));
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.pop();
+      off();
+      mgr.push('c');
+      expect(depths).toEqual([1, 2, 1]);
+    });
+  });
+});

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -4,6 +4,25 @@
 
 DOM-based screen switching. `ScreenManager` handles show/hide with `onActivate`/`onDeactivate` lifecycle. Combat is the default screen; Map lazy-creates the three.js world map on first visit. A persistent XP bar sits directly above the bottom nav, visible on every game screen.
 
+### Navigation stack (roots + pushes)
+
+`ScreenManager` models two separate axes, matching the standard mobile tab-bar-plus-stack pattern:
+
+- **Roots** — the top-level destinations owned by the bottom nav. `switchTo(id)` discards any drill-down and starts a fresh stack of depth 1. Re-selecting the current root while deep pops back to it.
+- **Pushes** — drill-downs on top of the current root. `push(id, params)` stacks a screen, `pop()` removes it. `params` reaches the screen via `onActivate(params?)`; screens that take none can keep declaring `onActivate(): void`.
+
+`getRootScreenId()` is what the bottom nav should highlight; `getActiveScreenId()` is what's visible. `onStackChange(cb)` fires on every depth change.
+
+**Browser/hardware back is wired in.** Each `push` calls `history.pushState({ ipDepth })`; a `popstate` carrying a shallower depth pops the stack. That makes the browser back button, Android's hardware key, and the in-app back arrow the same gesture. Entries not created by `ScreenManager` are ignored via the `ipDepth` marker.
+
+**One shared header, not one per screen.** `ScreenManager` mounts a single `#screen-header` above `#screen-container` with a back button and title, shown only at depth > 1 — roots are already identified by the nav tab, so a title bar there would just cost vertical space. Titles come from the optional 4th argument to `register(id, el, screen, title)` and are set via `textContent`, never `innerHTML`. The back button carries `aria-label="Go back"` and a 44px minimum target.
+
+`body.dataset.navDepth` mirrors the current depth so global CSS can react (e.g. hiding the nav in a drill-down).
+
+### Limited scrolling
+
+The app is built to read as a mobile app rather than a set of long pages: **screens do not scroll, designated regions inside them do.** `.screen` is `overflow: hidden`, and content that genuinely needs to scroll opts in by wrapping in `.screen-scroll` (a `flex: 1; min-height: 0; overflow-y: auto` region with `overscroll-behavior: contain`). Content that would otherwise stack into one tall screen becomes a `push` instead.
+
 ## Bottom nav structure
 
 Six tabs, three behavioral modes:


### PR DESCRIPTION
The client was a flat set of twelve sibling screens: `switchTo(id)`, no history, no way back. That works for a tab bar but not for drill-down — which is what's needed to stop stacking content into long scrolling pages.

## Two axes
- **Roots** are the top-level destinations owned by the bottom nav. `switchTo()` discards any drill-down and starts a fresh stack.
- **Pushes** are drill-downs. `push(id, params)` stacks a screen, `pop()` removes it, and `params` reach the screen via `onActivate(params?)`.

`getRootScreenId()` is what the nav should highlight, `getActiveScreenId()` is what's visible, `onStackChange()` fires on every depth change.

## Browser and hardware back
Each push calls `history.pushState({ ipDepth })`, and a `popstate` carrying a shallower depth pops the stack — so the in-app arrow, the browser button, and Android's hardware key are one gesture. History entries without the `ipDepth` marker are ignored, so we never react to someone else's state.

## One header, not twelve
The back header is owned by `ScreenManager` rather than implemented per screen — a back affordance built twelve times behaves twelve ways. It appears only at depth > 1, since roots are already identified by the nav tab and a redundant title bar costs vertical space. Titles use `textContent`, never `innerHTML`, because they'll carry player-supplied text. `aria-label="Go back"`, 44px target, safe-area padding.

## Limited scrolling
Adds `.screen-scroll`. `.screen` is already `overflow: hidden`, so screens never scroll as a whole; content that must scroll opts in explicitly. The rule is that a list scrolls and a screen does not.

## Backward compatible
`register()` gained an optional 4th argument and `Screen.onActivate()` gained an optional parameter, so all existing screens and call sites are unchanged.

## Testing
18 new tests covering roots, push/pop, depth, header visibility, title escaping, and listener teardown. `tsc --build` clean, 252 tests pass.

## No patch notes
Nothing pushes yet, so there's no player-visible change until the first screen adopts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)