### PR TITLE
Make patch notes a pushed screen — first use of the nav stack

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -35,6 +35,7 @@
         <div id="screen-social" class="screen"></div>
         <div id="screen-craft" class="screen"></div>
         <div id="screen-settings" class="screen"></div>
+        <div id="screen-patch-notes" class="screen"></div>
       </div>
       <div id="persistent-xp-bar"></div>
       <nav id="bottom-nav"></nav>

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -10,6 +10,7 @@ import { OfflineScreen } from './screens/OfflineScreen';
 import { CombatScreen } from './screens/CombatScreen';
 import { MapScreen } from './screens/MapScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
+import { PatchNotesScreen } from './screens/PatchNotesScreen';
 import { CharItemsScreen } from './screens/CharItemsScreen';
 import { SocialScreen } from './screens/SocialScreen';
 import { CraftingScreen } from './screens/CraftingScreen';
@@ -362,7 +363,10 @@ export class App {
     const charItemsScreen = new CharItemsScreen('screen-items', this.gameClient, this.worldCache);
     const socialScreen = new SocialScreen('screen-social', this.gameClient, this.chatStore, this.worldCache);
     const craftingScreen = new CraftingScreen('screen-craft', this.gameClient);
-    const settingsScreen = new SettingsScreen('screen-settings', this.gameClient);
+    const settingsScreen = new SettingsScreen('screen-settings', this.gameClient, (id) =>
+      this.screenManager.push(id),
+    );
+    const patchNotesScreen = new PatchNotesScreen('screen-patch-notes');
 
     // Wire map username click to social screen popup
     mapScreen.setOnUserClick((username, anchor, tileCol, tileRow) => {
@@ -392,6 +396,8 @@ export class App {
     this.screenManager.register('social', document.getElementById('screen-social')!, socialScreen);
     this.screenManager.register('craft', document.getElementById('screen-craft')!, craftingScreen);
     this.screenManager.register('settings', document.getElementById('screen-settings')!, settingsScreen);
+    // Title is supplied here because it is only ever shown as a pushed screen.
+    this.screenManager.register('patch-notes', document.getElementById('screen-patch-notes')!, patchNotesScreen, 'Patch Notes');
 
     // Show bottom nav + persistent XP bar
     this.navEl.style.display = '';

--- a/client/src/screens/PatchNotesScreen.ts
+++ b/client/src/screens/PatchNotesScreen.ts
@@ -1,0 +1,57 @@
+import type { Screen } from './ScreenManager';
+import { PATCH_NOTES } from './PatchNotes';
+
+/**
+ * Patch notes as a real pushed screen.
+ *
+ * This used to be a panel inside SettingsScreen, shown and hidden by
+ * toggling `style.display` on three sibling elements and served by a
+ * hand-rolled "Back" button. That is a drill-down faked in place: it had no
+ * history entry, so the browser and Android back buttons did nothing, and
+ * `onActivate` had to reset the three elements in case the user left the
+ * screen while the panel was open.
+ *
+ * As a push it gets the shared back header, real history, and no reset
+ * logic — leaving the screen pops it like anything else.
+ *
+ * The list is the only scrolling region; the screen itself does not scroll.
+ */
+export class PatchNotesScreen implements Screen {
+  private container: HTMLElement;
+
+  constructor(containerId: string) {
+    const el = document.getElementById(containerId);
+    if (!el) throw new Error(`Screen container #${containerId} not found`);
+    this.container = el;
+
+    this.container.innerHTML = `
+      <div class="patch-notes-list screen-scroll">
+        ${PATCH_NOTES.map(p => `
+          <div class="patch-note-entry">
+            <div class="patch-note-version">${escapeHtml(p.version)}</div>
+            <ul class="patch-note-items">
+              ${p.notes.map(n => `<li>${escapeHtml(n)}</li>`).join('')}
+            </ul>
+          </div>
+        `).join('')}
+      </div>
+    `;
+  }
+
+  onActivate(): void {
+    // Scroll back to the newest entry each time it is opened.
+    this.container.querySelector('.screen-scroll')?.scrollTo(0, 0);
+  }
+
+  onDeactivate(): void {
+    // no-op — nothing to tear down
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/client/src/screens/ScreenManager.ts
+++ b/client/src/screens/ScreenManager.ts
@@ -1,51 +1,211 @@
+/**
+ * Screen navigation.
+ *
+ * Two axes, deliberately separate:
+ *
+ * - **Roots** are the top-level destinations owned by the bottom nav. Switching
+ *   root (`switchTo`) discards any drill-down and starts a fresh stack. There is
+ *   always exactly one root.
+ * - **Pushes** are drill-downs on top of the current root (`push`). They stack,
+ *   they get a back header, and they are popped by the back button — the app's
+ *   own, the browser's, and Android's hardware key, which are all the same
+ *   thing via `popstate`.
+ *
+ * This is the iOS/Android tab-bar-plus-stack model. It exists so the game reads
+ * as a mobile app rather than a set of long scrolling pages: content that used
+ * to be stacked into one tall screen becomes a push instead.
+ */
+
 export interface Screen {
-  onActivate(): void;
+  /**
+   * Called when the screen becomes visible. `params` carries whatever `push`
+   * was given — screens that take no parameters can keep declaring
+   * `onActivate(): void`, which stays assignable.
+   */
+  onActivate(params?: unknown): void;
   onDeactivate(): void;
 }
 
 interface RegisteredScreen {
   element: HTMLElement;
   screen: Screen;
+  /** Header title used when this screen is pushed. Roots never show a header. */
+  title?: string;
+}
+
+interface StackEntry {
+  id: string;
+  params?: unknown;
+}
+
+/** Marks our own history entries so we ignore states pushed by anything else. */
+interface NavHistoryState {
+  ipDepth: number;
+}
+
+function isNavState(value: unknown): value is NavHistoryState {
+  return typeof value === 'object' && value !== null && typeof (value as NavHistoryState).ipDepth === 'number';
 }
 
 export class ScreenManager {
   private screens = new Map<string, RegisteredScreen>();
-  private activeScreenId: string | null = null;
+  private stack: StackEntry[] = [];
+  private headerEl: HTMLElement | null = null;
+  private titleEl: HTMLElement | null = null;
+  private stackListeners = new Set<(depth: number) => void>();
+  /** Set while we drive history ourselves, so our own popstate is a no-op. */
+  private suppressPopstate = false;
 
-  register(id: string, element: HTMLElement, screen: Screen): void {
-    this.screens.set(id, { element, screen });
+  constructor() {
+    this.mountHeader();
+    window.addEventListener('popstate', (e) => this.handlePopstate(e));
   }
 
+  register(id: string, element: HTMLElement, screen: Screen, title?: string): void {
+    this.screens.set(id, { element, screen, title });
+  }
+
+  /**
+   * Switch to a top-level destination, discarding any drill-down. This is what
+   * a bottom-nav tab does. Re-selecting the current root while deep in a stack
+   * pops back to it — matching how tab bars behave everywhere else.
+   */
   switchTo(id: string): void {
-    if (this.activeScreenId === id) return;
+    if (this.stack.length === 1 && this.stack[0].id === id) return;
+    this.stack = [{ id }];
+    this.replaceHistory();
+    this.applyTop();
+  }
 
-    // Deactivate the tracked active screen
-    const current = this.activeScreenId ? this.screens.get(this.activeScreenId) : undefined;
-    if (current) {
-      current.element.classList.remove('active');
-      current.screen.onDeactivate();
-    }
+  /** Drill down. The current screen stays mounted underneath, deactivated. */
+  push(id: string, params?: unknown): void {
+    if (!this.screens.has(id)) return;
+    this.stack.push({ id, params });
+    this.suppressPopstate = true;
+    history.pushState({ ipDepth: this.stack.length } satisfies NavHistoryState, '');
+    this.suppressPopstate = false;
+    this.applyTop();
+  }
 
-    // Remove stale active classes from all other screens (e.g. HTML-defined defaults)
+  /**
+   * Go back one level. Returns false at the root, so callers can fall through
+   * to whatever "back" means there (usually nothing).
+   */
+  pop(): boolean {
+    if (this.stack.length <= 1) return false;
+    this.stack.pop();
+    this.suppressPopstate = true;
+    history.back();
+    this.suppressPopstate = false;
+    this.applyTop();
+    return true;
+  }
+
+  canGoBack(): boolean {
+    return this.stack.length > 1;
+  }
+
+  /** Id of the visible screen, whether it is a root or a pushed one. */
+  getActiveScreenId(): string | null {
+    return this.stack.length ? this.stack[this.stack.length - 1].id : null;
+  }
+
+  /** Id of the current root — what the bottom nav should show as selected. */
+  getRootScreenId(): string | null {
+    return this.stack.length ? this.stack[0].id : null;
+  }
+
+  /** Notified on every depth change, so the nav can hide itself in a drill-down. */
+  onStackChange(cb: (depth: number) => void): () => void {
+    this.stackListeners.add(cb);
+    return () => this.stackListeners.delete(cb);
+  }
+
+  // ── internals ─────────────────────────────────────────────
+
+  /**
+   * One shared header rather than one per screen: a back affordance that is
+   * implemented twelve times is a back affordance that behaves twelve ways.
+   * It only appears at depth > 1 — roots are already identified by the nav
+   * tab, and a redundant title bar costs vertical space the screens need.
+   */
+  private mountHeader(): void {
+    const container = document.getElementById('screen-container');
+    if (!container || !container.parentElement) return;
+
+    const header = document.createElement('header');
+    header.id = 'screen-header';
+    header.hidden = true;
+
+    const back = document.createElement('button');
+    back.type = 'button';
+    back.className = 'screen-header-back';
+    back.setAttribute('aria-label', 'Go back');
+    back.innerHTML = '<span aria-hidden="true">‹</span>';
+    back.addEventListener('click', () => this.pop());
+
+    const title = document.createElement('h1');
+    title.className = 'screen-header-title';
+
+    header.append(back, title);
+    container.parentElement.insertBefore(header, container);
+
+    this.headerEl = header;
+    this.titleEl = title;
+  }
+
+  private handlePopstate(e: PopStateEvent): void {
+    if (this.suppressPopstate) return;
+    // Ignore history entries we did not create.
+    if (!isNavState(e.state) && this.stack.length <= 1) return;
+
+    const targetDepth = isNavState(e.state) ? e.state.ipDepth : 1;
+    if (targetDepth >= this.stack.length) return;
+
+    this.stack.length = Math.max(1, targetDepth);
+    this.applyTop();
+  }
+
+  private replaceHistory(): void {
+    this.suppressPopstate = true;
+    history.replaceState({ ipDepth: 1 } satisfies NavHistoryState, '');
+    this.suppressPopstate = false;
+  }
+
+  /** Render whatever is on top of the stack and deactivate everything else. */
+  private applyTop(): void {
+    const top = this.stack[this.stack.length - 1];
+    if (!top) return;
+
     for (const [screenId, registered] of this.screens) {
-      if (screenId !== id) {
+      if (screenId === top.id) continue;
+      if (registered.element.classList.contains('active')) {
+        registered.element.classList.remove('active');
+        registered.screen.onDeactivate();
+      } else {
+        // Clears stale `active` set in the HTML before any switch happened.
         registered.element.classList.remove('active');
       }
     }
 
-    const next = this.screens.get(id);
+    const next = this.screens.get(top.id);
     if (next) {
       next.element.classList.add('active');
-      next.screen.onActivate();
+      next.screen.onActivate(top.params);
     }
 
-    this.activeScreenId = id;
-    // Expose the active screen on the body so global CSS can adapt
-    // (e.g. mobile chat sheet replaces the combat log instead of stacking).
-    document.body.dataset.activeScreen = id;
+    this.updateHeader(next?.title);
+    document.body.dataset.activeScreen = top.id;
+    document.body.dataset.navDepth = String(this.stack.length);
+
+    for (const cb of this.stackListeners) cb(this.stack.length);
   }
 
-  getActiveScreenId(): string | null {
-    return this.activeScreenId;
+  private updateHeader(title?: string): void {
+    if (!this.headerEl || !this.titleEl) return;
+    const deep = this.stack.length > 1;
+    this.headerEl.hidden = !deep;
+    // textContent, not innerHTML — titles can carry player-supplied text.
+    this.titleEl.textContent = deep ? (title ?? '') : '';
   }
 }

--- a/client/src/screens/SettingsScreen.ts
+++ b/client/src/screens/SettingsScreen.ts
@@ -1,5 +1,4 @@
 import type { Screen } from './ScreenManager';
-import { PATCH_NOTES } from './PatchNotes';
 import { logout } from '../network/AuthClient';
 import { getQuestHintsEnabled, setQuestHintsEnabled } from '../settings/UserSettings';
 import { bringToFront, release, wireFocusOnInteract } from '../ui/ModalStack';
@@ -14,7 +13,12 @@ export class SettingsScreen implements Screen {
   private optionsOverlay: HTMLElement | null = null;
   private notifPrefsOverlay: HTMLElement | null = null;
 
-  constructor(containerId: string, private gameClient: GameClient) {
+  constructor(
+    containerId: string,
+    private gameClient: GameClient,
+    /** Drill down to a pushed screen. Wired by App to ScreenManager.push. */
+    private onOpenScreen: (id: string) => void,
+  ) {
     const el = document.getElementById(containerId);
     if (!el) throw new Error(`Screen container #${containerId} not found`);
     this.container = el;
@@ -32,44 +36,16 @@ export class SettingsScreen implements Screen {
           <button class="pixel-btn settings-btn" id="btn-patch-notes">Patch Notes</button>
           <button class="pixel-btn settings-btn settings-btn-danger" id="btn-sign-out">Sign Out</button>
         </div>
-        <div id="patch-notes-panel" class="patch-notes-panel" style="display:none;">
-          <button class="pixel-btn patch-notes-back" id="btn-patch-back">Back</button>
-          <div class="patch-notes-list">
-            ${PATCH_NOTES.map(p => `
-              <div class="patch-note-entry">
-                <div class="patch-note-version">${p.version}</div>
-                <ul class="patch-note-items">
-                  ${p.notes.map(n => `<li>${n}</li>`).join('')}
-                </ul>
-              </div>
-            `).join('')}
-          </div>
-        </div>
       </div>
     `;
 
     const btnPlayerOptions = this.container.querySelector('#btn-player-options') as HTMLButtonElement;
     const btnNotifications = this.container.querySelector('#btn-notifications') as HTMLButtonElement;
     const btnPatchNotes = this.container.querySelector('#btn-patch-notes') as HTMLButtonElement;
-    const btnBack = this.container.querySelector('#btn-patch-back') as HTMLButtonElement;
-    const patchPanel = this.container.querySelector('#patch-notes-panel') as HTMLElement;
-    const buttonsSection = this.container.querySelector('.settings-buttons') as HTMLElement;
-    const headerSection = this.container.querySelector('.settings-header') as HTMLElement;
 
     btnPlayerOptions.addEventListener('click', () => this.openPlayerOptions());
     btnNotifications.addEventListener('click', () => this.openNotificationPreferences());
-
-    btnPatchNotes.addEventListener('click', () => {
-      buttonsSection.style.display = 'none';
-      headerSection.style.display = 'none';
-      patchPanel.style.display = '';
-    });
-
-    btnBack.addEventListener('click', () => {
-      patchPanel.style.display = 'none';
-      buttonsSection.style.display = '';
-      headerSection.style.display = '';
-    });
+    btnPatchNotes.addEventListener('click', () => this.onOpenScreen('patch-notes'));
 
     const btnSignOut = this.container.querySelector('#btn-sign-out') as HTMLButtonElement;
     btnSignOut.addEventListener('click', async () => {
@@ -171,13 +147,8 @@ export class SettingsScreen implements Screen {
   }
 
   onActivate(): void {
-    // Reset to main settings view
-    const patchPanel = this.container.querySelector('#patch-notes-panel') as HTMLElement;
-    const buttonsSection = this.container.querySelector('.settings-buttons') as HTMLElement;
-    const headerSection = this.container.querySelector('.settings-header') as HTMLElement;
-    patchPanel.style.display = 'none';
-    buttonsSection.style.display = '';
-    headerSection.style.display = '';
+    // Nothing to reset — patch notes is a pushed screen now, so returning
+    // here means it has already been popped.
   }
 
   onDeactivate(): void {

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -938,25 +938,22 @@ html, body {
   border-color: var(--color-danger, #c0392b);
 }
 
-.patch-notes-panel {
-  width: 100%;
-  max-width: 500px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.patch-notes-back {
-  align-self: flex-start;
-  padding: 8px 12px;
-  font-size: 11px;
-  font-family: var(--pixel-font);
-}
-
+/*
+ * Patch notes is its own pushed screen — the back affordance comes from
+ * ScreenManager's shared header, so the old `.patch-notes-panel` wrapper
+ * and `.patch-notes-back` button are gone.
+ *
+ * The list is the screen's single scroll region (`.screen-scroll`); the
+ * screen itself does not scroll.
+ */
 .patch-notes-list {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  width: 100%;
+  max-width: 500px;
+  margin-inline: auto;
+  padding: 16px;
 }
 
 .patch-note-entry {

--- a/client/src/styles/pixel-theme.css
+++ b/client/src/styles/pixel-theme.css
@@ -118,6 +118,79 @@ html, body {
   flex-direction: column;
 }
 
+/* ── Screen Header (drill-down back bar) ─────────────────── */
+
+/*
+ * One shared header owned by ScreenManager, shown only at nav depth > 1.
+ * Root screens are already identified by the bottom nav, so they get no
+ * title bar — vertical space is the scarce resource on a phone.
+ */
+#screen-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 48px;
+  padding: 0 8px;
+  background: var(--bg-panel);
+  border-bottom: 2px solid var(--border-pixel);
+  /* Notched phones: this is the topmost chrome once a screen is pushed. */
+  padding-top: env(safe-area-inset-top, 0px);
+}
+
+#screen-header[hidden] {
+  display: none;
+}
+
+.screen-header-back {
+  /* 44px minimum target — see WCAG 2.5.8. */
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--pixel-font);
+  font-size: 32px;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.screen-header-back:active {
+  color: var(--accent-gold);
+}
+
+.screen-header-title {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-family: var(--display-font);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * Designated scroll region. `.screen` is already overflow:hidden, so screens
+ * never scroll as a whole — content that must scroll opts in explicitly by
+ * wrapping in this class. That is the mechanism behind "limited scrolling":
+ * a list scrolls, a screen does not.
+ */
+.screen-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* ── Pixel Panel (reusable) ──────────────────────────────── */
 
 .pixel-panel {

--- a/client/tests/PatchNotesScreen.test.ts
+++ b/client/tests/PatchNotesScreen.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PatchNotesScreen } from '../src/screens/PatchNotesScreen';
+import { PATCH_NOTES } from '../src/screens/PatchNotes';
+
+describe('PatchNotesScreen', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="screen-patch-notes" class="screen"></div>';
+  });
+
+  it('throws when its container is missing', () => {
+    document.body.innerHTML = '';
+    expect(() => new PatchNotesScreen('screen-patch-notes')).toThrow(/not found/);
+  });
+
+  it('renders one entry per release, newest first', () => {
+    new PatchNotesScreen('screen-patch-notes');
+    const entries = document.querySelectorAll('.patch-note-entry');
+    expect(entries).toHaveLength(PATCH_NOTES.length);
+    expect(document.querySelector('.patch-note-version')!.textContent).toBe(PATCH_NOTES[0].version);
+  });
+
+  it('renders every bullet of the newest release', () => {
+    new PatchNotesScreen('screen-patch-notes');
+    const first = document.querySelector('.patch-note-entry')!;
+    expect(first.querySelectorAll('.patch-note-items li')).toHaveLength(PATCH_NOTES[0].notes.length);
+  });
+
+  it('marks the list as the single scroll region', () => {
+    new PatchNotesScreen('screen-patch-notes');
+    // `.screen` is overflow:hidden, so without this the list would clip
+    // instead of scrolling.
+    expect(document.querySelector('.patch-notes-list.screen-scroll')).not.toBeNull();
+  });
+
+  it('escapes note text rather than interpolating it as markup', () => {
+    // The previous in-Settings version interpolated `${n}` raw. Notes are
+    // developer-authored so this was not a live vector, but a stray `<` in a
+    // bullet would silently eat the rest of the line.
+    const original = [...PATCH_NOTES];
+    PATCH_NOTES.length = 0;
+    PATCH_NOTES.push({ version: '9.9.9.9', notes: ['fixed <img src=x onerror=alert(1)> rendering'] });
+    try {
+      new PatchNotesScreen('screen-patch-notes');
+      const li = document.querySelector('.patch-note-items li')!;
+      expect(li.querySelector('img')).toBeNull();
+      expect(li.textContent).toContain('<img src=x onerror=alert(1)>');
+    } finally {
+      PATCH_NOTES.length = 0;
+      PATCH_NOTES.push(...original);
+    }
+  });
+});

--- a/client/tests/ScreenManager.test.ts
+++ b/client/tests/ScreenManager.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ScreenManager, type Screen } from '../src/screens/ScreenManager';
+
+/** Records activate/deactivate order so tests can assert on lifecycle, not just classes. */
+class FakeScreen implements Screen {
+  activations: unknown[] = [];
+  deactivations = 0;
+
+  onActivate(params?: unknown): void {
+    this.activations.push(params);
+  }
+
+  onDeactivate(): void {
+    this.deactivations += 1;
+  }
+}
+
+function setupDom(): void {
+  document.body.innerHTML = `
+    <div id="app">
+      <div id="screen-container">
+        <div id="screen-a" class="screen"></div>
+        <div id="screen-b" class="screen"></div>
+        <div id="screen-c" class="screen"></div>
+      </div>
+    </div>
+  `;
+  delete document.body.dataset.activeScreen;
+  delete document.body.dataset.navDepth;
+}
+
+function build(): { mgr: ScreenManager; a: FakeScreen; b: FakeScreen; c: FakeScreen } {
+  const mgr = new ScreenManager();
+  const a = new FakeScreen();
+  const b = new FakeScreen();
+  const c = new FakeScreen();
+  mgr.register('a', document.getElementById('screen-a')!, a);
+  mgr.register('b', document.getElementById('screen-b')!, b, 'Screen B');
+  mgr.register('c', document.getElementById('screen-c')!, c, 'Screen C');
+  return { mgr, a, b, c };
+}
+
+const header = () => document.getElementById('screen-header')!;
+const headerTitle = () => header().querySelector('.screen-header-title')!;
+
+describe('ScreenManager', () => {
+  beforeEach(() => {
+    setupDom();
+    history.replaceState(null, '');
+  });
+
+  describe('roots', () => {
+    it('activates the screen it switches to', () => {
+      const { mgr, a } = build();
+      mgr.switchTo('a');
+      expect(a.activations).toHaveLength(1);
+      expect(document.getElementById('screen-a')!.classList.contains('active')).toBe(true);
+      expect(document.body.dataset.activeScreen).toBe('a');
+    });
+
+    it('deactivates the previous root when switching', () => {
+      const { mgr, a, b } = build();
+      mgr.switchTo('a');
+      mgr.switchTo('b');
+      expect(a.deactivations).toBe(1);
+      expect(document.getElementById('screen-a')!.classList.contains('active')).toBe(false);
+      expect(b.activations).toHaveLength(1);
+    });
+
+    it('is a no-op when switching to the already-active root', () => {
+      const { mgr, a } = build();
+      mgr.switchTo('a');
+      mgr.switchTo('a');
+      expect(a.activations).toHaveLength(1);
+      expect(a.deactivations).toBe(0);
+    });
+
+    it('starts at depth 1 with no back available', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      expect(mgr.canGoBack()).toBe(false);
+      expect(document.body.dataset.navDepth).toBe('1');
+    });
+  });
+
+  describe('push and pop', () => {
+    it('pushing keeps the root as the reported root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      expect(mgr.getRootScreenId()).toBe('a');
+      expect(mgr.getActiveScreenId()).toBe('b');
+      expect(mgr.canGoBack()).toBe(true);
+      expect(document.body.dataset.navDepth).toBe('2');
+    });
+
+    it('passes params through to onActivate', () => {
+      const { mgr, b } = build();
+      mgr.switchTo('a');
+      mgr.push('b', { slot: 'chest' });
+      expect(b.activations).toEqual([{ slot: 'chest' }]);
+    });
+
+    it('pops back to the screen underneath and reactivates it', () => {
+      const { mgr, a, b } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      expect(mgr.pop()).toBe(true);
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(a.activations).toHaveLength(2);
+      expect(b.deactivations).toBe(1);
+    });
+
+    it('refuses to pop at the root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      expect(mgr.pop()).toBe(false);
+      expect(mgr.getActiveScreenId()).toBe('a');
+    });
+
+    it('stacks more than one level deep', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.push('c');
+      expect(document.body.dataset.navDepth).toBe('3');
+      mgr.pop();
+      expect(mgr.getActiveScreenId()).toBe('b');
+      mgr.pop();
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(mgr.canGoBack()).toBe(false);
+    });
+
+    it('discards the drill-down when a new root is selected', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.push('c');
+      mgr.switchTo('a');
+      expect(mgr.canGoBack()).toBe(false);
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(document.body.dataset.navDepth).toBe('1');
+    });
+
+    it('ignores a push to an unregistered screen', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('nope');
+      expect(mgr.getActiveScreenId()).toBe('a');
+      expect(mgr.canGoBack()).toBe(false);
+    });
+  });
+
+  describe('header', () => {
+    it('stays hidden at the root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      expect(header().hidden).toBe(true);
+    });
+
+    it('appears with the pushed screen title', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      expect(header().hidden).toBe(false);
+      expect(headerTitle().textContent).toBe('Screen B');
+    });
+
+    it('hides again after popping back to the root', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.pop();
+      expect(header().hidden).toBe(true);
+      expect(headerTitle().textContent).toBe('');
+    });
+
+    it('sets the title as text, never as markup', () => {
+      const { mgr } = build();
+      mgr.register('x', document.getElementById('screen-c')!, new FakeScreen(), '<img src=x onerror=alert(1)>');
+      mgr.switchTo('a');
+      mgr.push('x');
+      expect(headerTitle().querySelector('img')).toBeNull();
+      expect(headerTitle().textContent).toBe('<img src=x onerror=alert(1)>');
+    });
+
+    it('has an accessible back control', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      const back = header().querySelector('.screen-header-back')!;
+      expect(back.getAttribute('aria-label')).toBe('Go back');
+    });
+
+    it('pops when the back control is clicked', () => {
+      const { mgr } = build();
+      mgr.switchTo('a');
+      mgr.push('b');
+      (header().querySelector('.screen-header-back') as HTMLElement).click();
+      expect(mgr.getActiveScreenId()).toBe('a');
+    });
+  });
+
+  describe('stack listeners', () => {
+    it('reports each depth change and stops after unsubscribe', () => {
+      const { mgr } = build();
+      const depths: number[] = [];
+      const off = mgr.onStackChange((d) => depths.push(d));
+      mgr.switchTo('a');
+      mgr.push('b');
+      mgr.pop();
+      off();
+      mgr.push('c');
+      expect(depths).toEqual([1, 2, 1]);
+    });
+  });
+});

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -4,6 +4,25 @@
 
 DOM-based screen switching. `ScreenManager` handles show/hide with `onActivate`/`onDeactivate` lifecycle. Combat is the default screen; Map lazy-creates the three.js world map on first visit. A persistent XP bar sits directly above the bottom nav, visible on every game screen.
 
+### Navigation stack (roots + pushes)
+
+`ScreenManager` models two separate axes, matching the standard mobile tab-bar-plus-stack pattern:
+
+- **Roots** — the top-level destinations owned by the bottom nav. `switchTo(id)` discards any drill-down and starts a fresh stack of depth 1. Re-selecting the current root while deep pops back to it.
+- **Pushes** — drill-downs on top of the current root. `push(id, params)` stacks a screen, `pop()` removes it. `params` reaches the screen via `onActivate(params?)`; screens that take none can keep declaring `onActivate(): void`.
+
+`getRootScreenId()` is what the bottom nav should highlight; `getActiveScreenId()` is what's visible. `onStackChange(cb)` fires on every depth change.
+
+**Browser/hardware back is wired in.** Each `push` calls `history.pushState({ ipDepth })`; a `popstate` carrying a shallower depth pops the stack. That makes the browser back button, Android's hardware key, and the in-app back arrow the same gesture. Entries not created by `ScreenManager` are ignored via the `ipDepth` marker.
+
+**One shared header, not one per screen.** `ScreenManager` mounts a single `#screen-header` above `#screen-container` with a back button and title, shown only at depth > 1 — roots are already identified by the nav tab, so a title bar there would just cost vertical space. Titles come from the optional 4th argument to `register(id, el, screen, title)` and are set via `textContent`, never `innerHTML`. The back button carries `aria-label="Go back"` and a 44px minimum target.
+
+`body.dataset.navDepth` mirrors the current depth so global CSS can react (e.g. hiding the nav in a drill-down).
+
+### Limited scrolling
+
+The app is built to read as a mobile app rather than a set of long pages: **screens do not scroll, designated regions inside them do.** `.screen` is `overflow: hidden`, and content that genuinely needs to scroll opts in by wrapping in `.screen-scroll` (a `flex: 1; min-height: 0; overflow-y: auto` region with `overscroll-behavior: contain`). Content that would otherwise stack into one tall screen becomes a `push` instead.
+
 ## Bottom nav structure
 
 Six tabs, three behavioral modes:


### PR DESCRIPTION
> **Stacked on #362.** This branches from the nav-stack branch because it depends on `ScreenManager.push()`, so the diff here includes #362's commit. Merge #362 first.

#362 added a navigation stack with **zero call sites**. This gives it one, using the clearest existing drill-down in the client.

## The problem
Patch notes was a panel inside `SettingsScreen`, shown and hidden by toggling `style.display` on three sibling elements, served by a hand-rolled "Back" button. That's a drill-down faked in place:

- no history entry, so the browser and Android back buttons did nothing
- `onActivate` had to reset all three elements, in case the user tab-swapped away while the panel was open
- the back button was a second, inconsistent implementation of an affordance the shell should own

## After
A pushed screen. It gets the shared back header, real history, and no reset logic — leaving pops it like anything else. `SettingsScreen` loses the panel markup, the back button, two element lookups, and its `onActivate` body.

Also the first user of `.screen-scroll`: the notes list scrolls, the screen does not.

## Incidental fix
The old version interpolated `${p.version}` and `${n}` straight into `innerHTML`. Notes are developer-authored so this was never a live vector, but a stray `<` in a bullet would silently eat the rest of the line. The new screen escapes, with a test covering it.

## Testing
5 new tests (entry rendering, bullet count, scroll region, escaping, missing container). `tsc --build` clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)