### PR TITLE
Add a skill asset kind

### DIFF
--- a/server/src/game/AssetCoverage.ts
+++ b/server/src/game/AssetCoverage.ts
@@ -138,6 +138,7 @@ function fromContent(record: Record<string, unknown>): RequiredId[] {
 function requiredIdsFor(kind: AssetKind, info: AssetKindInfo, content: ContentStore): RequiredId[] {
   switch (info.idSource) {
     case 'items': return fromContent(content.getAllItems());
+    case 'skills': return fromContent(content.getAllSkills());
     case 'monsters': return fromContent(content.getAllMonsters());
     case 'sets': return fromContent(content.getAllSets());
     case 'tileTypes': return fromContent(content.getAllTileTypes());

--- a/server/tests/AssetCoverage.test.ts
+++ b/server/tests/AssetCoverage.test.ts
@@ -125,6 +125,23 @@ describe('computeAssetCoverage counts', () => {
     expect(monsters.mount).toBe('/monster-artwork');
   });
 
+  it('enumerates skills so the skill kind reports real gaps rather than an empty set', async () => {
+    // Skills were the last content type with no asset kind, so this pins the
+    // enumeration: a required count of zero here would silently report full
+    // coverage no matter how much art was missing.
+    const { content, assets } = await setup();
+    const skillIds = Object.keys(content.getAllSkills());
+    expect(skillIds.length).toBeGreaterThan(0);
+    await assets.write('skill', skillIds[0], SQUARE);
+
+    const skills = kindOf(await computeAssetCoverage(content, assets, { kind: 'skill' }), 'skill');
+    expect(skills.required).toBe(skillIds.length);
+    expect(skills.present).toBe(1);
+    expect(skills.missing).toBe(skillIds.length - 1);
+    expect(skills.orphans).toEqual([]);
+    expect(skills.mount).toBe('/skill-artwork');
+  });
+
   it('reports zero required ids for the room-override kind, which only ever holds optional art', async () => {
     const { content, assets } = await setup();
     const report = await computeAssetCoverage(content, assets, { kind: 'tile' });

--- a/shared/src/assets/AssetKinds.ts
+++ b/shared/src/assets/AssetKinds.ts
@@ -31,6 +31,7 @@ export const ASSET_KINDS = [
   'class-icon',
   'slot-icon',
   'nav-icon',
+  'skill',
 ] as const;
 
 export type AssetKind = (typeof ASSET_KINDS)[number];
@@ -42,6 +43,7 @@ export type AssetKind = (typeof ASSET_KINDS)[number];
  */
 export type AssetIdSource =
   | 'items'
+  | 'skills'
   | 'monsters'
   | 'sets'
   | 'shops'
@@ -269,6 +271,15 @@ export const ASSET_KIND_INFO: Record<AssetKind, AssetKindInfo> = {
     idFormat: 'Nav destination id',
     shape: 'square',
   },
+  skill: {
+    label: 'Skill',
+    description: 'Skill icons shown on the equipped-skill slots and in the skill picker.',
+    dir: 'data/skill-artwork',
+    mount: '/skill-artwork',
+    idSource: 'skills',
+    idFormat: 'SkillDefinition.id',
+    shape: 'square',
+  },
 };
 
 /**
@@ -295,6 +306,7 @@ export const MANAGED_ASSET_KINDS = [
   'class-icon',
   'slot-icon',
   'nav-icon',
+  'skill',
 ] as const;
 
 export type ManagedAssetKind = (typeof MANAGED_ASSET_KINDS)[number];


### PR DESCRIPTION
Skills were the only content type with **no asset kind**, so skill icons had nowhere to be uploaded — the admin UI, the assets API and the MCP tools all had no way to accept them.

## Three files, because the registry does the rest

- **shared** — `skill` joins `ASSET_KINDS` and `MANAGED_ASSET_KINDS`, with an `ASSET_KIND_INFO` row pointing at `data/skill-artwork` and a new `skills` id source.
- **server** — `AssetCoverage` enumerates `ContentStore.getAllSkills()` for that source, so the coverage report shows real gaps.

Nothing else needed touching. The express static mounts, the vite dev proxy, the admin upload routes, the MCP tool enum and the swagger spec **all derive from the shared registry already** — which is exactly what the comment on the mount loop promises ("adding a kind is one row in `ASSET_KIND_INFO`"). So this is mostly a check that the promise holds, and it does.

## Testing
`tsc --build` clean, full suite green. The new test pins the enumeration specifically: a `required` count of zero would silently report full coverage no matter how much art was missing, which is the failure mode worth catching.

## Context
The client already renders skill icons on the equipped-skill slots and picker rows (separate change, #363). This is the missing server half that lets the art actually be uploaded. I have 55 skill icons ready to push through the API once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)