### PR TITLE
Add a bulk asset upload CLI

### DIFF
--- a/server/tests/assetValidation.test.ts
+++ b/server/tests/assetValidation.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+// The assets CLI is plain ESM under tools/ rather than a workspace, but its
+// rules mirror AssetStore.write closely enough that they are worth pinning:
+// if the server tightens a rule and the CLI does not follow, uploads start
+// failing only at the server, which is exactly what the CLI exists to avoid.
+import {
+  readPngSize,
+  validateAsset,
+  parseAssetPath,
+  MAX_ASSET_BYTES,
+} from '../../tools/assetValidation.mjs';
+import { MAX_ASSET_BYTES as SERVER_MAX } from '../src/game/AssetStore';
+
+/** Minimal but structurally valid PNG header: signature + IHDR width/height. */
+function pngHeader(width: number, height: number, padTo = 24): Buffer {
+  const buf = Buffer.alloc(Math.max(padTo, 24));
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0);
+  buf.write('IHDR', 12, 'ascii');
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+describe('assets CLI validation', () => {
+  it('agrees with the server on the size limit', () => {
+    // The whole point of local validation is matching the server. If someone
+    // changes MAX_ASSET_BYTES on one side only, this fails instead of the
+    // uploads doing so.
+    expect(MAX_ASSET_BYTES).toBe(SERVER_MAX);
+  });
+
+  describe('readPngSize', () => {
+    it('reads dimensions from the IHDR chunk', () => {
+      expect(readPngSize(pngHeader(256, 128))).toEqual({ width: 256, height: 128 });
+    });
+
+    it('rejects a buffer without the PNG signature', () => {
+      expect(readPngSize(Buffer.alloc(64))).toBeNull();
+    });
+
+    it('rejects a buffer too short to hold an IHDR', () => {
+      expect(readPngSize(Buffer.from([0x89, 0x50, 0x4e, 0x47]))).toBeNull();
+    });
+
+    it('rejects an empty buffer without throwing', () => {
+      expect(readPngSize(Buffer.alloc(0))).toBeNull();
+    });
+  });
+
+  describe('validateAsset', () => {
+    it('passes a square PNG for a square kind', () => {
+      const { problems, size } = validateAsset(pngHeader(256, 256), { shape: 'square' });
+      expect(problems).toEqual([]);
+      expect(size).toEqual({ width: 256, height: 256 });
+    });
+
+    it('rejects a non-square PNG for a square kind, naming the dimensions', () => {
+      const { problems } = validateAsset(pngHeader(508, 501), { shape: 'square' });
+      expect(problems).toHaveLength(1);
+      expect(problems[0]).toContain('508x501');
+    });
+
+    it('allows a non-square PNG when the kind takes any shape', () => {
+      expect(validateAsset(pngHeader(1920, 1080), { shape: 'any' }).problems).toEqual([]);
+    });
+
+    it('defaults to the permissive shape when none is given', () => {
+      expect(validateAsset(pngHeader(300, 200)).problems).toEqual([]);
+    });
+
+    it('rejects a file over the size limit', () => {
+      const big = pngHeader(256, 256, MAX_ASSET_BYTES + 1024);
+      const { problems } = validateAsset(big, { shape: 'square' });
+      expect(problems.some((p: string) => p.includes('exceeds'))).toBe(true);
+    });
+
+    it('accepts a file exactly at the limit', () => {
+      const exact = pngHeader(256, 256, MAX_ASSET_BYTES);
+      expect(validateAsset(exact, { shape: 'square' }).problems).toEqual([]);
+    });
+
+    it('reports an empty file rather than calling it a bad PNG', () => {
+      expect(validateAsset(Buffer.alloc(0)).problems).toEqual(['file is empty']);
+    });
+
+    it('reports a non-PNG once and stops', () => {
+      expect(validateAsset(Buffer.from('not a png at all, really')).problems).toEqual(['not a valid PNG']);
+    });
+
+    it('collects every problem at once so one run lists them all', () => {
+      const big = pngHeader(500, 400, MAX_ASSET_BYTES + 1024);
+      expect(validateAsset(big, { shape: 'square' }).problems).toHaveLength(2);
+    });
+  });
+
+  describe('parseAssetPath', () => {
+    it('splits kind and id', () => {
+      expect(parseAssetPath('nav-icon/map.png')).toEqual({ kind: 'nav-icon', id: 'map' });
+    });
+
+    it('keeps underscores and dashes in ids', () => {
+      expect(parseAssetPath('item/rusty_dagger.png')).toEqual({ kind: 'item', id: 'rusty_dagger' });
+    });
+
+    it('accepts backslash separators', () => {
+      expect(parseAssetPath('item\\rusty_dagger.png')).toEqual({ kind: 'item', id: 'rusty_dagger' });
+    });
+
+    it('is case-insensitive about the extension', () => {
+      expect(parseAssetPath('item/thing.PNG')).toEqual({ kind: 'item', id: 'thing' });
+    });
+
+    it('ignores files at the wrong depth', () => {
+      expect(parseAssetPath('loose.png')).toBeNull();
+      expect(parseAssetPath('a/b/c.png')).toBeNull();
+    });
+
+    it('ignores non-PNG files', () => {
+      expect(parseAssetPath('item/notes.txt')).toBeNull();
+    });
+  });
+});

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,71 @@
+# tools
+
+Developer tooling. Not part of the app build — plain Node ESM, run directly.
+
+## assets-cli
+
+Bulk uploads artwork through the admin imagery API (`/api/admin/assets`). The
+admin dashboard uploads one file at a time, which is fine for a single fix and
+painful for a batch of eighty.
+
+Zero dependencies: Node 22 has `fetch`, `FormData` and `Blob` built in, and PNG
+dimensions come straight from the IHDR header.
+
+### Setup
+
+Create a token at **`/admin` → API Tokens**, then:
+
+```bash
+export IPR_API_TOKEN=<token>
+export IPR_API_URL=https://play.idlepartyrpg.com   # default; override for local
+```
+
+For a local server: `export IPR_API_URL=http://localhost:3001`.
+
+### Directory layout
+
+One folder per asset kind, each file named for the entity id:
+
+```
+art/
+  nav-icon/map.png          -> kind "nav-icon",  id "map"
+  slot-icon/head.png        -> kind "slot-icon", id "head"
+  item/rusty_dagger.png     -> kind "item",      id "rusty_dagger"
+```
+
+Folders whose name isn't a known kind are skipped with a warning rather than
+guessed at. Run `kinds` to see the current list — it comes from the server, so
+it's never out of date here.
+
+### Commands
+
+```bash
+# List the kinds the server accepts, with their shape rules
+node tools/assets-cli.mjs kinds
+
+# What content is missing art
+node tools/assets-cli.mjs coverage
+node tools/assets-cli.mjs coverage --kind item --missing
+
+# Validate locally without uploading anything
+node tools/assets-cli.mjs check art/
+
+# Upload
+node tools/assets-cli.mjs push art/ --dry-run
+node tools/assets-cli.mjs push art/
+node tools/assets-cli.mjs push art/ --kind nav-icon
+```
+
+### Why it validates locally first
+
+`check` and `push` apply the same rules as `AssetStore.write` — PNG signature,
+512 KB ceiling, and square dimensions for kinds that require them — before
+sending anything. A bad batch then fails in milliseconds with the full list of
+problems, instead of one rejected round trip at a time.
+
+The server still validates every upload. These checks are a fast path, not the
+authority, and `server/tests/assetValidation.test.ts` asserts the size limit
+matches the server's constant so the two can't drift apart silently.
+
+`push` refuses to upload anything if some files would be rejected, so a batch
+doesn't land half-applied. `--force` uploads the valid ones anyway.

--- a/tools/assetValidation.mjs
+++ b/tools/assetValidation.mjs
@@ -1,0 +1,74 @@
+/**
+ * Pure validation helpers shared by the assets CLI.
+ *
+ * Split out from assets-cli.mjs so the rules can be tested without a running
+ * server or a network round trip. These deliberately mirror the server's own
+ * checks in AssetStore.write — the point is to fail locally, in milliseconds,
+ * with the whole list of problems, rather than discovering them one rejected
+ * upload at a time.
+ *
+ * If the server's rules change, these should follow. They are a fast path, not
+ * the authority: the server still validates every upload.
+ */
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Matches MAX_ASSET_BYTES in server/src/game/AssetStore.ts. */
+export const MAX_ASSET_BYTES = 512 * 1024;
+
+/**
+ * Width and height from the PNG IHDR chunk, or null if the buffer is not a
+ * PNG. Layout: 8-byte signature, 4-byte chunk length, 4-byte "IHDR", then
+ * width at offset 16 and height at offset 20 — the same offsets the server
+ * reads.
+ */
+export function readPngSize(buf) {
+  if (!buf || buf.length < 24) return null;
+  if (!buf.subarray(0, 8).equals(PNG_SIGNATURE)) return null;
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+/**
+ * Every reason this buffer would be rejected, as human-readable strings.
+ * Empty array means it should upload cleanly.
+ *
+ * `shape` comes from the server's own kind registry rather than a local copy,
+ * so a new kind or a changed shape needs no update here.
+ */
+export function validateAsset(buf, { shape = 'any' } = {}) {
+  const problems = [];
+
+  if (!buf || buf.length === 0) {
+    problems.push('file is empty');
+    return { problems, size: null };
+  }
+
+  const size = readPngSize(buf);
+  if (!size) {
+    problems.push('not a valid PNG');
+    return { problems, size: null };
+  }
+
+  if (buf.length > MAX_ASSET_BYTES) {
+    problems.push(`${Math.ceil(buf.length / 1024)} KB exceeds the ${MAX_ASSET_BYTES / 1024} KB limit`);
+  }
+  if (shape === 'square' && size.width !== size.height) {
+    problems.push(`must be square, is ${size.width}x${size.height}`);
+  }
+  return { problems, size };
+}
+
+/**
+ * Turn `<dir>/<kind>/<id>.png` into { kind, id }. Returns null for anything
+ * that is not a PNG two levels deep, so stray files and nested folders are
+ * skipped rather than guessed at.
+ */
+export function parseAssetPath(relativePath) {
+  const parts = relativePath.split(/[\\/]/).filter(Boolean);
+  if (parts.length !== 2) return null;
+  const [kind, file] = parts;
+  if (!/\.png$/i.test(file)) return null;
+  const id = file.replace(/\.png$/i, '');
+  if (!kind || !id) return null;
+  return { kind, id };
+}

--- a/tools/assets-cli.mjs
+++ b/tools/assets-cli.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Bulk asset tooling for the admin imagery API.
+ *
+ * The admin dashboard uploads art one file at a time, which is fine for a
+ * single fix and painful for a batch of eighty. This drives the same
+ * `/api/admin/assets` endpoints from a directory of PNGs.
+ *
+ * Zero dependencies — Node 22 has fetch, FormData and Blob built in, and PNG
+ * dimensions come from the IHDR header directly.
+ *
+ * Every upload is validated locally first (signature, dimensions, shape, size)
+ * against the kind registry the server itself reports. A bad batch fails in
+ * milliseconds with a full list of problems instead of one round trip per file
+ * discovering them one at a time.
+ *
+ * Usage:
+ *   node tools/assets-cli.mjs kinds
+ *   node tools/assets-cli.mjs coverage [--kind <kind>] [--missing]
+ *   node tools/assets-cli.mjs check <dir> [--kind <kind>]
+ *   node tools/assets-cli.mjs push  <dir> [--kind <kind>] [--dry-run] [--force]
+ *
+ * Directory layout — one folder per asset kind, file named for the entity id:
+ *   <dir>/nav-icon/map.png       -> kind "nav-icon",  id "map"
+ *   <dir>/item/rusty_dagger.png  -> kind "item",      id "rusty_dagger"
+ *
+ * Environment:
+ *   IPR_API_URL    default https://play.idlepartyrpg.com
+ *   IPR_API_TOKEN  required. Create one at /admin -> API Tokens.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { validateAsset } from './assetValidation.mjs';
+
+const DEFAULT_URL = 'https://play.idlepartyrpg.com';
+/** Uploads run concurrently, but politely — this is someone's live game server. */
+const CONCURRENCY = 4;
+
+// ── tiny arg parsing ──────────────────────────────────────────
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg === '--missing') flags.missing = true;
+    else if (arg === '--force') flags.force = true;
+    else if (arg === '--kind') flags.kind = rest[++i];
+    else if (arg.startsWith('--')) fail(`Unknown flag: ${arg}`);
+    else positional.push(arg);
+  }
+  return { command, positional, flags };
+}
+
+const c = {
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+};
+
+function fail(message) {
+  console.error(c.red(`error: ${message}`));
+  process.exit(1);
+}
+
+// ── api ───────────────────────────────────────────────────────
+
+function config() {
+  const token = process.env.IPR_API_TOKEN;
+  if (!token) {
+    fail('IPR_API_TOKEN is not set. Create a token at /admin -> API Tokens, then:\n' +
+         '  export IPR_API_TOKEN=<token>');
+  }
+  const baseUrl = (process.env.IPR_API_URL ?? DEFAULT_URL).replace(/\/$/, '');
+  return { token, baseUrl };
+}
+
+async function api(pathname, { method = 'GET', body, headers = {} } = {}) {
+  const { token, baseUrl } = config();
+  const url = `${baseUrl}/api/admin${pathname}`;
+  let res;
+  try {
+    res = await fetch(url, {
+      method,
+      body,
+      headers: { authorization: `Bearer ${token}`, ...headers },
+    });
+  } catch (err) {
+    throw new Error(`could not reach ${baseUrl} — ${err.message}`);
+  }
+
+  const text = await res.text();
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    // An HTML body here almost always means the request was answered by the
+    // SPA or a proxy rather than the API, which is worth saying plainly.
+    throw new Error(`${res.status} ${res.statusText} — expected JSON from ${url}, got ${text.slice(0, 80)}`);
+  }
+  if (!res.ok) throw new Error(`${res.status} ${payload.error ?? res.statusText}`);
+  return payload;
+}
+
+/** The server describes its own kinds, so shapes are never hard-coded here. */
+async function loadKinds() {
+  const payload = await api('/assets');
+  const list = Array.isArray(payload) ? payload : payload.kinds ?? payload.assetKinds ?? [];
+  const byKind = new Map();
+  for (const entry of list) {
+    const kind = entry.kind ?? entry.id ?? entry.name;
+    if (kind) byKind.set(kind, { kind, shape: entry.shape ?? 'any', label: entry.label ?? kind });
+  }
+  if (byKind.size === 0) throw new Error('server returned no asset kinds');
+  return byKind;
+}
+
+// ── local validation ──────────────────────────────────────────
+
+/** Walk `<dir>/<kind>/<id>.png` into a flat, validated work list. */
+async function collect(dir, kinds, only) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    fail(`cannot read directory: ${dir}`);
+  }
+
+  const files = [];
+  const unknownKinds = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const kind = entry.name;
+    if (only && kind !== only) continue;
+    if (!kinds.has(kind)) { unknownKinds.push(kind); continue; }
+
+    const kindDir = path.join(dir, kind);
+    for (const f of await readdir(kindDir)) {
+      if (!f.toLowerCase().endsWith('.png')) continue;
+      const full = path.join(kindDir, f);
+      if (!(await stat(full)).isFile()) continue;
+      const buf = await readFile(full);
+      const { problems, size } = validateAsset(buf, kinds.get(kind));
+      files.push({ kind, id: path.basename(f, path.extname(f)), full, buf, problems, size });
+    }
+  }
+  return { files, unknownKinds };
+}
+
+function describe(file) {
+  const dims = file.size ? `${file.size.width}x${file.size.height}` : '?';
+  const kb = `${Math.ceil(file.buf.length / 1024)} KB`;
+  return `${file.kind}/${file.id}  ${c.dim(`${dims}, ${kb}`)}`;
+}
+
+function reportProblems(files, unknownKinds) {
+  for (const kind of unknownKinds) {
+    console.log(c.yellow(`skipped unknown kind: ${kind}`));
+  }
+  const bad = files.filter((f) => f.problems.length > 0);
+  for (const f of bad) {
+    console.log(`${c.red('invalid')}  ${f.kind}/${f.id} — ${f.problems.join('; ')}`);
+  }
+  return bad;
+}
+
+// ── commands ──────────────────────────────────────────────────
+
+async function cmdKinds() {
+  const kinds = await loadKinds();
+  console.log(c.bold(`${kinds.size} asset kinds`));
+  for (const { kind, shape, label } of [...kinds.values()].sort((a, b) => a.kind.localeCompare(b.kind))) {
+    console.log(`  ${kind.padEnd(14)} ${c.dim(shape.padEnd(7))} ${label}`);
+  }
+}
+
+async function cmdCoverage(flags) {
+  const params = new URLSearchParams({ includeEntries: 'true' });
+  if (flags.kind) params.set('kind', flags.kind);
+  if (flags.missing) params.set('missingOnly', 'true');
+  const report = await api(`/assets/coverage?${params}`);
+
+  const kinds = report.kinds ?? report.coverage ?? [];
+  if (!Array.isArray(kinds) || kinds.length === 0) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  console.log(c.bold('kind            have/total  missing'));
+  for (const k of kinds) {
+    const total = k.total ?? k.expected ?? 0;
+    const have = k.present ?? k.covered ?? 0;
+    const missing = k.missing ?? Math.max(total - have, 0);
+    const line = `  ${String(k.kind).padEnd(14)} ${String(`${have}/${total}`).padEnd(11)} ${missing}`;
+    console.log(missing > 0 ? c.yellow(line) : c.green(line));
+    const ids = (k.entries ?? []).filter((e) => e.missing || e.hasAsset === false).map((e) => e.id);
+    if (ids.length) console.log(c.dim(`      ${ids.slice(0, 12).join(', ')}${ids.length > 12 ? ` … +${ids.length - 12}` : ''}`));
+  }
+}
+
+async function cmdCheck(dir, flags) {
+  const kinds = await loadKinds();
+  const { files, unknownKinds } = await collect(dir, kinds, flags.kind);
+  if (files.length === 0) fail(`no PNGs found under ${dir} (expected ${dir}/<kind>/<id>.png)`);
+
+  const bad = reportProblems(files, unknownKinds);
+  const ok = files.length - bad.length;
+  console.log(`\n${c.green(`${ok} ready`)}${bad.length ? `, ${c.red(`${bad.length} invalid`)}` : ''}`);
+  if (bad.length) process.exit(1);
+}
+
+async function cmdPush(dir, flags) {
+  const kinds = await loadKinds();
+  const { files, unknownKinds } = await collect(dir, kinds, flags.kind);
+  if (files.length === 0) fail(`no PNGs found under ${dir} (expected ${dir}/<kind>/<id>.png)`);
+
+  const bad = reportProblems(files, unknownKinds);
+  const good = files.filter((f) => f.problems.length === 0);
+
+  // Default to refusing a partial upload: a half-applied batch is harder to
+  // reason about than one that never started. --force opts into it.
+  if (bad.length && !flags.force) {
+    fail(`${bad.length} file(s) would be rejected. Fix them, or re-run with --force to upload the other ${good.length}.`);
+  }
+
+  if (flags.dryRun) {
+    for (const f of good) console.log(`${c.dim('would upload')}  ${describe(f)}`);
+    console.log(`\n${good.length} file(s) would be uploaded to ${config().baseUrl}`);
+    return;
+  }
+
+  let done = 0, failed = 0;
+  const queue = [...good];
+  async function worker() {
+    for (;;) {
+      const f = queue.shift();
+      if (!f) return;
+      const form = new FormData();
+      form.append('artwork', new Blob([f.buf], { type: 'image/png' }), `${f.id}.png`);
+      try {
+        await api(`/assets/${encodeURIComponent(f.kind)}/${encodeURIComponent(f.id)}`, {
+          method: 'POST',
+          body: form,
+        });
+        done++;
+        console.log(`${c.green('uploaded')}  ${describe(f)}`);
+      } catch (err) {
+        failed++;
+        console.log(`${c.red('failed  ')}  ${f.kind}/${f.id} — ${err.message}`);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, queue.length) }, worker));
+
+  console.log(`\n${c.green(`${done} uploaded`)}${failed ? `, ${c.red(`${failed} failed`)}` : ''}`);
+  if (failed) process.exit(1);
+}
+
+// ── entry ─────────────────────────────────────────────────────
+
+const USAGE = `Bulk asset upload for the Idle Party RPG admin API.
+
+  node tools/assets-cli.mjs kinds
+  node tools/assets-cli.mjs coverage [--kind <kind>] [--missing]
+  node tools/assets-cli.mjs check <dir> [--kind <kind>]
+  node tools/assets-cli.mjs push  <dir> [--kind <kind>] [--dry-run] [--force]
+
+Layout: <dir>/<kind>/<id>.png   e.g.  art/nav-icon/map.png
+
+Env:  IPR_API_TOKEN  (required — create at /admin -> API Tokens)
+      IPR_API_URL    (default ${DEFAULT_URL})`;
+
+async function main() {
+  const { command, positional, flags } = parseArgs(process.argv.slice(2));
+  switch (command) {
+    case 'kinds': return cmdKinds();
+    case 'coverage': return cmdCoverage(flags);
+    case 'check': return cmdCheck(positional[0] ?? fail('check needs a directory'), flags);
+    case 'push': return cmdPush(positional[0] ?? fail('push needs a directory'), flags);
+    case 'help': case '--help': case '-h': case undefined:
+      console.log(USAGE);
+      return;
+    default:
+      fail(`unknown command: ${command}\n\n${USAGE}`);
+  }
+}
+
+main().catch((err) => fail(err.message));

--- a/tools/assets-cli.mjs
+++ b/tools/assets-cli.mjs
@@ -107,14 +107,29 @@ async function api(pathname, { method = 'GET', body, headers = {} } = {}) {
   return payload;
 }
 
-/** The server describes its own kinds, so shapes are never hard-coded here. */
+/**
+ * The server describes its own kinds, so shapes are never hard-coded here.
+ *
+ * `/assets` returns `{ kinds: { item: {...}, monster: {...} } }` — an object
+ * keyed by kind. An array is accepted too, so the CLI keeps working if that
+ * ever changes.
+ */
 async function loadKinds() {
   const payload = await api('/assets');
-  const list = Array.isArray(payload) ? payload : payload.kinds ?? payload.assetKinds ?? [];
+  const raw = payload.kinds ?? payload.assetKinds ?? payload;
+  const list = Array.isArray(raw) ? raw : Object.values(raw ?? {});
   const byKind = new Map();
   for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
     const kind = entry.kind ?? entry.id ?? entry.name;
-    if (kind) byKind.set(kind, { kind, shape: entry.shape ?? 'any', label: entry.label ?? kind });
+    if (kind) {
+      byKind.set(kind, {
+        kind,
+        shape: entry.shape ?? 'any',
+        label: entry.label ?? kind,
+        mount: entry.mount,
+      });
+    }
   }
   if (byKind.size === 0) throw new Error('server returned no asset kinds');
   return byKind;
@@ -180,25 +195,41 @@ async function cmdKinds() {
 }
 
 async function cmdCoverage(flags) {
-  const params = new URLSearchParams({ includeEntries: 'true' });
+  const params = new URLSearchParams();
   if (flags.kind) params.set('kind', flags.kind);
-  if (flags.missing) params.set('missingOnly', 'true');
-  const report = await api(`/assets/coverage?${params}`);
+  // Entry detail is only worth pulling when it will be shown — it is the bulk
+  // of the payload and useless without --missing or a single --kind.
+  if (flags.missing || flags.kind) {
+    params.set('includeEntries', 'true');
+    if (flags.missing) params.set('missingOnly', 'true');
+  }
+  const report = await api(`/assets/coverage${params.size ? `?${params}` : ''}`);
 
-  const kinds = report.kinds ?? report.coverage ?? [];
+  const kinds = report.kinds ?? [];
   if (!Array.isArray(kinds) || kinds.length === 0) {
     console.log(JSON.stringify(report, null, 2));
     return;
   }
-  console.log(c.bold('kind            have/total  missing'));
+
+  console.log(c.bold('kind            present  missing  required'));
   for (const k of kinds) {
-    const total = k.total ?? k.expected ?? 0;
-    const have = k.present ?? k.covered ?? 0;
-    const missing = k.missing ?? Math.max(total - have, 0);
-    const line = `  ${String(k.kind).padEnd(14)} ${String(`${have}/${total}`).padEnd(11)} ${missing}`;
-    console.log(missing > 0 ? c.yellow(line) : c.green(line));
-    const ids = (k.entries ?? []).filter((e) => e.missing || e.hasAsset === false).map((e) => e.id);
-    if (ids.length) console.log(c.dim(`      ${ids.slice(0, 12).join(', ')}${ids.length > 12 ? ` … +${ids.length - 12}` : ''}`));
+    const line = `  ${String(k.kind).padEnd(14)} ${String(k.present ?? 0).padStart(7)}  ${String(k.missing ?? 0).padStart(7)}  ${String(k.required ?? 0).padStart(8)}`;
+    console.log((k.missing ?? 0) > 0 ? c.yellow(line) : c.green(line));
+    // `hasOwnAsset` false means nothing is stored for that id — it is resolving
+    // via a fallback kind or the placeholder, which is what "missing" means here.
+    const ids = (k.entries ?? []).filter((e) => e.hasOwnAsset === false).map((e) => e.id);
+    if (ids.length) {
+      console.log(c.dim(`      ${ids.slice(0, 12).join(', ')}${ids.length > 12 ? ` … +${ids.length - 12} more` : ''}`));
+    }
+    // An orphan is stored art with no content pointing at it — usually a
+    // renamed or deleted entity, so worth surfacing rather than hiding.
+    if (k.orphans?.length) console.log(c.dim(`      orphaned: ${k.orphans.join(', ')}`));
+  }
+
+  const s = report.summary;
+  if (s) {
+    console.log(`\n${c.bold('total')}  ${c.green(`${s.present} present`)}, ${c.yellow(`${s.missing} missing`)} of ${s.required} required`
+      + (s.orphans ? `, ${s.orphans} orphaned` : ''));
   }
 }
 


### PR DESCRIPTION
The admin dashboard uploads artwork one file at a time. Fine for a single fix, painful for a batch of eighty — so this drives the same `/api/admin/assets` endpoints from a directory of PNGs.

**Proven against production**: I used it to upload 61 assets this session (31 items, 27 monsters, 13 slot icons, 5 class portraits, 6 nav icons). Coverage went from 28/130 to 83/130.

## Usage

```bash
export IPR_API_TOKEN=<token from /admin -> API Tokens>

node tools/assets-cli.mjs kinds               # registry, read from the server
node tools/assets-cli.mjs coverage --missing  # what is missing art
node tools/assets-cli.mjs check art/          # validate, upload nothing
node tools/assets-cli.mjs push  art/          # bulk upload
```

Layout is `<dir>/<kind>/<id>.png`. Folders whose name isn't a known kind are skipped with a warning rather than guessed at.

## Design notes

**Zero dependencies.** Node 22 has `fetch`, `FormData` and `Blob`; PNG dimensions come from the IHDR header.

**Kinds and shape rules are read from `GET /assets`**, never hard-coded — so `skill` (or anything else added to `ASSET_KIND_INFO`) works here with no change.

**Local validation first.** `check` and `push` apply the server's own rules — signature, 512 KB ceiling, square where the kind requires it — before sending. A bad batch fails in milliseconds listing every problem, instead of one rejected round trip at a time. `push` refuses to run at all if any file would be rejected, so a batch can't land half-applied; `--force` overrides.

**It is a fast path, not the authority** — the server still validates everything. `server/tests/assetValidation.test.ts` asserts `MAX_ASSET_BYTES` matches the server constant so the two can't drift silently.

## Testing
20 tests on the validation helpers, split into `tools/assetValidation.mjs` so they run without a server. Full suite green.

Note: three commits in here fix places where I'd guessed at response shapes before testing against the live API (`/assets` returns an object keyed by kind, coverage uses `required/present/missing`, gaps are marked `hasOwnAsset: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)