### PR TITLE
Harden two set-bonus combat tests; record that seed data is not live content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ Everything in `data/` must be persisted behind a swappable store interface — n
 
 When adding a new content type to the game, include it in `ContentSnapshot` (`server/src/game/VersionStore.ts`) and in `ContentStore.toSnapshot()` / `replaceAll()` so it ships in draft/publish/deploy snapshots.
 
+### Seed data is not live content
+
+The game is content-managed: `ContentStore.load()` seeds defaults **only** when no data files exist at all. After first boot, each server's content is whatever lives in its own `data/`, authored through the World Manager and MCP and shipped via draft → publish → deploy. Different live servers can hold entirely different content.
+
+So never infer what the game contains from the source tree. Grepping the repo tells you what a *fresh* world starts with and what this checkout happens to hold — it does not tell you what any running server has. Claims like "nothing references X, so no live content is affected" are unsupportable; say "the seed defaults don't reference X" and treat the real blast radius as unknown. This matters most when writing issues, PR descriptions, or anything where a severity or priority depends on what operators actually authored.
+
 ### UI terminology
 
 In all user-facing text (UI labels, error messages, combat log), refer to hex tiles as **"rooms"**. Code internals (variable names, class names, comments) may still use "tile" — the rename is UI-only.

--- a/shared/tests/SetTypes.test.ts
+++ b/shared/tests/SetTypes.test.ts
@@ -422,37 +422,36 @@ describe('Combat integration — set bonuses are applied', () => {
   // Some cases below pin Math.random to make damage rolls deterministic.
   afterEach(() => { vi.restoreAllMocks(); });
 
-  it('damageResistancePercent reduces incoming monster damage', () => {
-    // Monster always hits for 100. Player has 50% damage resistance from a set.
-    // Without set: takes 100 damage. With set: takes 50.
-    const playerWithSet = makePlayer('hero', 0, {
-      hp: 200,
-      className: 'Knight',
-      setBonuses: { damageResistancePercent: 50 },
-    });
-    const playerNoSet = makePlayer('control', 0, {
-      hp: 200,
-      className: 'Knight',
-    });
-    const monsterDef = makeStaticMonster(100);
-    const monster = createMonsterInstance(monsterDef);
+  /**
+   * Run one player against a monster that always hits for 100, and report the
+   * HP lost. Give the player enough HP to survive the whole run: a player who
+   * dies mid-loop ends the battle, and `processPartyTick` then no-ops, so a
+   * dead arm silently stops accruing damage and the two arms stop being
+   * comparable. Combat alternates player, monster, player, ... so `ticks`
+   * ticks land `ticks / 2` monster attacks.
+   */
+  function hpLostAgainstStaticMonster(
+    ticks: number,
+    setBonuses?: SetBonuses,
+    equipBonuses?: PartyCombatant['equipBonuses'],
+  ): number {
+    const player = makePlayer('hero', 0, { hp: 1000, className: 'Knight', setBonuses });
+    player.equipBonuses = equipBonuses;
+    const monster = createMonsterInstance(makeStaticMonster(100));
     monster.gridPosition = 0;
 
-    const stateA = createPartyCombatState([playerWithSet], [monster]);
-    const stateB = createPartyCombatState([playerNoSet], [createMonsterInstance(monsterDef)]);
+    const state = createPartyCombatState([player], [monster]);
+    for (let i = 0; i < ticks; i++) processPartyTick(state);
+    return state.players[0].maxHp - state.players[0].currentHp;
+  }
 
-    // Tick: player attacks first (prelude), then monster attacks. Run a few ticks.
-    for (let i = 0; i < 4; i++) processPartyTick(stateA);
-    for (let i = 0; i < 4; i++) processPartyTick(stateB);
+  it('damageResistancePercent halves incoming monster damage', () => {
+    // Three monster attacks of 100: 300 unprotected, 150 behind a 50% resist.
+    const plain = hpLostAgainstStaticMonster(6);
+    const resisted = hpLostAgainstStaticMonster(6, { damageResistancePercent: 50 });
 
-    const hpLossA = stateA.players[0].maxHp - stateA.players[0].currentHp;
-    const hpLossB = stateB.players[0].maxHp - stateB.players[0].currentHp;
-
-    // The set-protected player should lose strictly less HP.
-    expect(hpLossA).toBeLessThan(hpLossB);
-    // And the loss should be roughly halved (allow some tolerance because both could
-    // include other reductions, but with no other defenses, A should be ~50% of B).
-    expect(hpLossA).toBeLessThanOrEqual(Math.ceil(hpLossB / 2) + 1);
+    expect(plain).toBe(300);
+    expect(resisted).toBe(150);
   });
 
   it('damagePercent scales player attack damage at every damage roll', () => {
@@ -495,34 +494,18 @@ describe('Combat integration — set bonuses are applied', () => {
   });
 
   it('damage resistance is applied BEFORE flat reductions', () => {
-    // Raw damage 100, 50% set resist → 50, then equip DR of 10 → final 40.
-    // Without the "before flat" rule, you'd see (100-10)*0.5 = 45.
-    // We can't observe the math directly without exposing internals, but we CAN
-    // check the order via behavior at the boundary — large flat reduction with small
-    // raw damage shouldn't underflow, etc. For now sanity: combined defenses don't
-    // subtract more than rawDamage and produce non-negative results.
-    const player = makePlayer('hero', 0, {
-      hp: 500,
-      className: 'Knight',
-      setBonuses: { damageResistancePercent: 50 },
-    });
-    player.equipBonuses = {
+    // Percent-then-flat: floor(100 * 0.5) - 10 = 40 per hit.
+    // Flat-then-percent would be (100 - 10) * 0.5 = 45 per hit.
+    // Over three monster attacks that is 120 vs 135 — so an exact assertion is
+    // what actually pins the ordering. The old bounds check (0 < lost < 400)
+    // was satisfied by both.
+    const lost = hpLostAgainstStaticMonster(6, { damageResistancePercent: 50 }, {
       bonusAttackMin: 0, bonusAttackMax: 0,
       damageReductionMin: 10, damageReductionMax: 10,
       magicReductionMin: 0, magicReductionMax: 0,
-    };
-    const monsterDef = makeStaticMonster(100);
-    const monster = createMonsterInstance(monsterDef);
-    monster.gridPosition = 0;
+    });
 
-    const state = createPartyCombatState([player], [monster]);
-    const startHp = state.players[0].currentHp;
-    for (let i = 0; i < 4; i++) processPartyTick(state);
-    const lost = startHp - state.players[0].currentHp;
-
-    // Some damage was dealt (resistance didn't drop it to 0) and we didn't take a full hit.
-    expect(lost).toBeGreaterThan(0);
-    expect(lost).toBeLessThan(100 * 4); // would be 400+ with no defenses
+    expect(lost).toBe(3 * 40);
   });
 });
 


### PR DESCRIPTION
Follow-ups to #373, which merged before these landed. Two small, independent changes.

## 1. Two combat tests that could not fail

Both were found by the sweep that root-caused the flake fixed in #373, and both are confirmed by mutating the engine and watching them go red.

**`damageResistancePercent reduces incoming monster damage`** compared two arms that were only comparable *by accident*. The control player died on exactly the last tick of the loop, which ends the battle and makes `processPartyTick` a no-op — so both arms happened to stop accruing damage at the same moment. Raising the loop from 4 ticks to 6 made it fail `150 <= 101`, because the protected arm kept bleeding while the dead one was frozen at 200.

Now both arms are given enough HP to survive the run, and the assertion is exact: 300 unprotected, 150 behind a 50% resist.

**`damage resistance is applied BEFORE flat reductions`** asserted only `0 < lost < 400`. Both orderings satisfy that, so the test could not fail:

| ordering | per hit | over 3 hits |
|---|---|---|
| percent then flat (actual) | `floor(100 × 0.5) − 10` = 40 | 120 |
| flat then percent | `(100 − 10) × 0.5` = 45 | 135 |

Now asserts the exact 120. Inverting the order in `CombatEngine.applyMonsterDirectDamage` fails it at 135 — re-verified against this branch's base.

Both tests share a new helper whose doc comment records the trap, since it is not obvious from the call site that a dead arm silently stops accumulating.

## 2. `CLAUDE.md`: seed data is not live content

I made a bad call while triaging #375: I grepped for `stone_wall`, found nothing referencing it, wrote "no live content is broken", and used that to downgrade the issue.

That reasoning does not hold here. `ContentStore.load()` seeds defaults **only** when no data files exist at all; after first boot each server's content is whatever lives in its own `data/`, authored through the World Manager and MCP and shipped via draft → publish → deploy. Different live servers can hold entirely different content, so a repo grep establishes what a *fresh* world starts with and nothing more.

Adds a short `CLAUDE.md` section under Content versioning saying so, aimed at issue/PR writing where a severity depends on what operators actually authored. The claim in #375 is corrected.

## Not fixed here

The rest of the sweep is filed, not fixed: #375 (passive-only encounters, plus reward credit for monsters that survive a win), #376 (renaming a live player drops them out of their own party's combat — verified `players: []` and an endless defeat loop), #377 (the remaining tests that cannot fail, including a Brace invariant whose guard can be deleted with all 16 tests still passing).

## Testing

925 tests green. No production code changes — one test file and one doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)