### PR TITLE
Support multiple game instances on one server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,28 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          # Deploys every instance installed on the host. The primary lives at
+          # /opt/idle-party-rpg; setup-prod.sh --instance NAME adds siblings at
+          # /opt/idle-party-rpg-NAME, and the directory name is also the unit name.
+          # One instance failing doesn't block the others — the job fails at the end.
           script: |
-            set -e
-            cd /opt/idle-party-rpg
-            git pull
-            npm install
-            npm run build
-            bash deploy/sync-nginx.sh
-            sudo systemctl restart idle-party-rpg
+            FAILED=""
+            for DIR in /opt/idle-party-rpg /opt/idle-party-rpg-*; do
+              [ -d "$DIR/.git" ] || continue
+              NAME=$(basename "$DIR")
+              echo "=== Deploying $NAME ($DIR) ==="
+              (
+                set -e
+                cd "$DIR"
+                git pull
+                npm install
+                npm run build
+                bash deploy/sync-nginx.sh
+                sudo systemctl restart "$NAME"
+              ) || FAILED="$FAILED $NAME"
+            done
+            if [ -n "$FAILED" ]; then
+              echo "Deploy failed for:$FAILED"
+              exit 1
+            fi
+            echo "All instances deployed."

--- a/README.md
+++ b/README.md
@@ -46,10 +46,42 @@ sudo bash setup-prod.sh
 
 The script will:
 1. Validate that node (22+), npm, nginx, and git are installed
-2. Prompt for domain, session secret, AWS SES credentials, and other config
+2. Prompt for instance name, domain, session secret, AWS SES credentials, and other config
 3. Clone the repo to `/opt/idle-party-rpg` and build
 4. Install and start a systemd service (`idle-party-rpg`)
 5. Configure nginx as a reverse proxy with WebSocket support
+6. Optionally issue a Let's Encrypt certificate with certbot — skip it if TLS
+   terminates upstream (e.g. behind the Cloudflare proxy). Use `--certbot` /
+   `--no-certbot` to answer that up front.
+
+### Running Multiple Instances
+
+Several independent games can share one server, each on its own domain. Pass
+`--instance NAME` to install a sibling alongside the primary:
+
+```bash
+sudo bash setup-prod.sh --instance game2
+```
+
+Every instance gets its own install directory, `.env`, `data/` folder, systemd
+unit, and nginx site — so players, accounts, and CMS content are fully separate:
+
+| | Primary | `--instance game2` |
+|---|---|---|
+| Install dir | `/opt/idle-party-rpg` | `/opt/idle-party-rpg-game2` |
+| Service | `idle-party-rpg` | `idle-party-rpg-game2` |
+| nginx site | `ipr-site.conf` | `ipr-site-game2.conf` |
+| Game data | `/opt/idle-party-rpg/data/` | `/opt/idle-party-rpg-game2/data/` |
+
+The install directory name is the source of truth — `deploy/sync-nginx.sh` and the
+deploy workflow both derive the service and nginx site names from it, so nothing
+else needs configuring.
+
+Each instance needs its own `PORT` (the script scans sibling installs, suggests
+the next free one, and refuses a collision) and its own `APP_URL`, which drives
+both magic-link redirects and the CORS origin. `SESSION_SECRET` should be distinct
+per instance. The SES credentials can be shared. Note that magic-link emails are
+branded "Idle Party RPG" regardless of instance — only the link URL differs.
 
 ### Environment Variables
 
@@ -70,12 +102,19 @@ The script will:
 ```bash
 sudo systemctl status idle-party-rpg   # check service
 journalctl -u idle-party-rpg -f        # follow logs
-sudo certbot --nginx -d yourdomain.com # add HTTPS
 ```
+
+For a named instance, append the instance name to the unit
+(`systemctl status idle-party-rpg-game2`).
+
+If you skipped certbot, point the domain at the server and terminate TLS upstream.
+With Cloudflare: an A record for the domain with the proxy enabled, SSL/TLS mode
+**Full**, and **WebSockets** enabled under Network (the game runs over a WS
+connection). nginx serves plain HTTP on `:80` behind the proxy.
 
 ## Auto-Deploy
 
-Pushes to `main` automatically deploy via GitHub Actions. The workflow SSHs into the server, pulls the latest code, builds, and restarts the service.
+Pushes to `main` automatically deploy via GitHub Actions. The workflow SSHs into the server, then for **every** instance it finds under `/opt/idle-party-rpg*` it pulls the latest code, builds, syncs nginx, and restarts that instance's service. A new instance is picked up automatically — no workflow change needed. If one instance fails, the rest still deploy and the job reports the failure at the end.
 
 **Required GitHub Secrets** (Settings → Secrets and variables → Actions):
 

--- a/deploy/idle-party-rpg.service.template
+++ b/deploy/idle-party-rpg.service.template
@@ -1,20 +1,20 @@
 [Unit]
-Description=Idle Party RPG Game Server
+Description=Idle Party RPG Game Server ({{INSTANCE_LABEL}})
 After=network.target
 
 [Service]
 Type=simple
-User=idlerpg
-Group=idlerpg
-WorkingDirectory=/opt/idle-party-rpg
+User={{SERVICE_USER}}
+Group={{SERVICE_USER}}
+WorkingDirectory={{INSTALL_DIR}}
 ExecStart=/usr/bin/node server/dist/index.js
-EnvironmentFile=/opt/idle-party-rpg/.env
+EnvironmentFile={{INSTALL_DIR}}/.env
 Environment=NODE_ENV=production
 Restart=always
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=idle-party-rpg
+SyslogIdentifier={{SERVICE_NAME}}
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/ipr-site.conf.template
+++ b/deploy/ipr-site.conf.template
@@ -3,7 +3,7 @@ server {
     server_name {{DOMAIN}};
 
     location / {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://localhost:{{PORT}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/deploy/sync-nginx.sh
+++ b/deploy/sync-nginx.sh
@@ -1,34 +1,68 @@
 #!/usr/bin/env bash
 # Sync nginx config from repo template to sites-available.
-# Designed to run as the idlerpg user during deploys.
+# Designed to run as the service user during deploys.
 # Requires sudoers entries for: cp, nginx -t, systemctl reload nginx
+#
+# Multi-instance: everything is derived from where this script lives, so a second
+# install at /opt/idle-party-rpg-<instance> syncs its own nginx site file and
+# never touches the first instance's. The naming rule matches setup-prod.sh:
+#   /opt/idle-party-rpg            -> ipr-site.conf
+#   /opt/idle-party-rpg-game2      -> ipr-site-game2.conf
 set -euo pipefail
 
-INSTALL_DIR="/opt/idle-party-rpg"
-NGINX_CONF="ipr-site.conf"
+INSTALL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+case "${INSTALL_DIR##*/}" in
+  idle-party-rpg)   SUFFIX="" ;;
+  idle-party-rpg-*) SUFFIX="-${INSTALL_DIR##*/idle-party-rpg-}" ;;
+  *) echo "[sync-nginx] Unexpected install dir '$INSTALL_DIR' — expected .../idle-party-rpg[-<instance>]"; exit 1 ;;
+esac
+NGINX_CONF="ipr-site${SUFFIX}.conf"
 TEMPLATE="$INSTALL_DIR/deploy/ipr-site.conf.template"
 TARGET="/etc/nginx/sites-available/$NGINX_CONF"
+ENV_FILE="$INSTALL_DIR/.env"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "[sync-nginx] Template not found: $TEMPLATE"
   exit 1
 fi
 
-# Extract domain from existing config (avoids needing .env parsing)
-if [[ -f "$TARGET" ]]; then
-  CURRENT_DOMAIN=$(grep 'server_name' "$TARGET" | awk '{print $2}' | tr -d ';')
-else
+if [[ ! -f "$TARGET" ]]; then
   echo "[sync-nginx] No existing nginx config at $TARGET — skipping (run setup-prod.sh first)"
+  exit 0
+fi
+
+if [[ ! -r "$ENV_FILE" ]]; then
+  echo "[sync-nginx] Cannot read $ENV_FILE — skipping"
+  exit 0
+fi
+
+# Domain and port both come from this instance's .env, so the rendered config
+# can never point at another instance's port.
+DOMAIN=$(grep '^APP_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed -e 's|^https://||' -e 's|^http://||' -e 's|/.*$||')
+PORT=$(grep '^PORT=' "$ENV_FILE" | head -1 | cut -d= -f2)
+PORT="${PORT:-3001}"
+
+if [[ -z "$DOMAIN" ]]; then
+  # Fall back to whatever the live config already serves.
+  DOMAIN=$(grep 'server_name' "$TARGET" | head -1 | awk '{print $2}' | tr -d ';')
+fi
+[[ -z "$DOMAIN" ]] && { echo "[sync-nginx] Could not determine domain — skipping"; exit 0; }
+
+# If certbot has taken over this site file it holds a TLS server block that the
+# repo template doesn't know about. Re-rendering would drop HTTPS, so bail out and
+# leave it to the operator (re-run setup-prod.sh to pull in template changes).
+if grep -q 'managed by Certbot' "$TARGET" 2>/dev/null; then
+  echo "[sync-nginx] $NGINX_CONF is certbot-managed — leaving it untouched"
   exit 0
 fi
 
 # Generate new config from template into a temp file
 TMPFILE=$(mktemp)
-sed "s/{{DOMAIN}}/$CURRENT_DOMAIN/g" "$TEMPLATE" > "$TMPFILE"
+sed -e "s/{{DOMAIN}}/$DOMAIN/g" -e "s/{{PORT}}/$PORT/g" "$TEMPLATE" > "$TMPFILE"
 
 # Compare with current config
 if diff -q "$TMPFILE" "$TARGET" >/dev/null 2>&1; then
-  echo "[sync-nginx] nginx config unchanged"
+  echo "[sync-nginx] nginx config unchanged ($NGINX_CONF)"
   rm "$TMPFILE"
   exit 0
 fi
@@ -36,7 +70,7 @@ fi
 # Copy new config and reload
 sudo cp "$TMPFILE" "$TARGET"
 rm "$TMPFILE"
-echo "[sync-nginx] Updated $TARGET"
+echo "[sync-nginx] Updated $TARGET ($DOMAIN -> localhost:$PORT)"
 
 sudo nginx -t
 sudo systemctl reload nginx

--- a/setup-prod.sh
+++ b/setup-prod.sh
@@ -2,10 +2,8 @@
 set -euo pipefail
 
 REPO_URL="git@github.com:lucashutyler/idle-party-hexagogo.git"
-INSTALL_DIR="/opt/idle-party-rpg"
-SERVICE_NAME="idle-party-rpg"
-NGINX_CONF="ipr-site.conf"
 SERVICE_USER="idlerpg"
+INSTALL_ROOT="${INSTALL_ROOT:-/opt}"
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -17,6 +15,39 @@ info()  { echo -e "${GREEN}[OK]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[!!]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 
+usage() {
+  cat <<USAGE
+Usage: sudo ./setup-prod.sh [--instance NAME] [--certbot | --no-certbot]
+
+  --instance NAME   Install a named instance alongside the primary one.
+                    Omit for the primary instance.
+  --certbot         Issue a Let's Encrypt certificate for the domain at the end.
+  --no-certbot      Skip the HTTPS prompt entirely (for proxied TLS, e.g. Cloudflare).
+                    Without either flag the script asks.
+
+Each instance gets its own install directory, .env, data/, systemd unit and
+nginx site, so several can run on one server behind different domains:
+
+  (primary)          /opt/idle-party-rpg         idle-party-rpg.service         ipr-site.conf
+  --instance game2   /opt/idle-party-rpg-game2   idle-party-rpg-game2.service   ipr-site-game2.conf
+USAGE
+  exit 0
+}
+
+# --- Parse args ---
+INSTANCE="${INSTANCE:-}"
+USE_CERTBOT=""   # "" = ask, "yes" / "no" = decided by flag
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --instance) INSTANCE="${2:-}"; shift 2 ;;
+    --instance=*) INSTANCE="${1#*=}"; shift ;;
+    --certbot) USE_CERTBOT="yes"; shift ;;
+    --no-certbot) USE_CERTBOT="no"; shift ;;
+    -h|--help) usage ;;
+    *) error "Unknown argument: $1 (try --help)" ;;
+  esac
+done
+
 # --- Must run as root ---
 if [[ $EUID -ne 0 ]]; then
   error "This script must be run as root (use sudo)"
@@ -24,6 +55,33 @@ fi
 
 echo ""
 echo "=== Idle Party RPG — Production Setup ==="
+echo ""
+
+# --- Resolve instance identity ---
+if [[ -z "$INSTANCE" ]]; then
+  echo "Leave blank for the primary instance, or name a second instance (e.g. game2)."
+  read -rp "Instance name []: " INSTANCE
+fi
+
+if [[ -n "$INSTANCE" ]]; then
+  [[ "$INSTANCE" =~ ^[a-z0-9][a-z0-9-]*$ ]] || \
+    error "Instance name must be lowercase letters, digits and dashes (got: $INSTANCE)"
+fi
+
+SUFFIX=""
+[[ -n "$INSTANCE" ]] && SUFFIX="-$INSTANCE"
+
+# These three names must stay in step with the derivation in deploy/sync-nginx.sh.
+INSTALL_DIR="$INSTALL_ROOT/idle-party-rpg$SUFFIX"
+SERVICE_NAME="idle-party-rpg$SUFFIX"
+NGINX_CONF="ipr-site$SUFFIX.conf"
+SUDOERS_FILE="/etc/sudoers.d/$SERVICE_USER-${INSTANCE:-default}"
+INSTANCE_LABEL="${INSTANCE:-primary}"
+
+info "Instance:     $INSTANCE_LABEL"
+info "Install dir:  $INSTALL_DIR"
+info "Service:      $SERVICE_NAME.service"
+info "nginx site:   $NGINX_CONF"
 echo ""
 
 # --- Validate prerequisites ---
@@ -47,6 +105,26 @@ info "git $(git --version | awk '{print $3}')"
 
 echo ""
 
+# --- Ports already claimed by other instances ---
+# Reads every sibling install's .env so a new instance can't silently collide.
+# Newline-separated "<port> <install dir>" lines (plain string, not an assoc array,
+# so this still runs under bash 3.x).
+USED_PORTS=""
+for env_file in "$INSTALL_ROOT"/idle-party-rpg*/.env; do
+  [[ -f "$env_file" ]] || continue
+  [[ "$env_file" == "$INSTALL_DIR/.env" ]] && continue
+  other_port=$(grep '^PORT=' "$env_file" | head -1 | cut -d= -f2 || true)
+  [[ -n "$other_port" ]] && USED_PORTS="$USED_PORTS$other_port ${env_file%/.env}
+"
+done
+
+port_owner() { echo "$USED_PORTS" | awk -v p="$1" '$1 == p { print $2; exit }'; }
+
+SUGGESTED_PORT=3001
+while [[ -n "$(port_owner "$SUGGESTED_PORT")" ]]; do
+  SUGGESTED_PORT=$((SUGGESTED_PORT + 1))
+done
+
 # --- Prompt for configuration ---
 SKIP_ENV=false
 if [[ -f "$INSTALL_DIR/.env" ]]; then
@@ -55,11 +133,13 @@ if [[ -f "$INSTALL_DIR/.env" ]]; then
   if [[ "$OVERWRITE_ENV" != "y" && "$OVERWRITE_ENV" != "Y" ]]; then
     SKIP_ENV=true
     info "Keeping existing .env"
-    # Still need DOMAIN for nginx config — extract from existing APP_URL
-    DOMAIN=$(grep '^APP_URL=' "$INSTALL_DIR/.env" | sed 's|APP_URL=https\?://||')
+    # Still need DOMAIN and PORT for the nginx config — take them from the existing .env
+    DOMAIN=$(grep '^APP_URL=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2- | sed -e 's|^https://||' -e 's|^http://||' -e 's|/.*$||')
     [[ -z "$DOMAIN" ]] && read -rp "Domain name (e.g. play.hexagogo.com): " DOMAIN
     [[ -z "$DOMAIN" ]] && error "Domain is required."
-    info "Using domain: $DOMAIN"
+    PORT=$(grep '^PORT=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2)
+    PORT="${PORT:-3001}"
+    info "Using domain: $DOMAIN (port $PORT)"
   fi
 fi
 
@@ -78,8 +158,15 @@ if [[ "$SKIP_ENV" == "false" ]]; then
   read -rp "App URL [$DEFAULT_APP_URL]: " APP_URL
   APP_URL="${APP_URL:-$DEFAULT_APP_URL}"
 
-  read -rp "Server port [3001]: " PORT
-  PORT="${PORT:-3001}"
+  if [[ -n "$USED_PORTS" ]]; then
+    echo ""
+    echo "Ports already in use by other instances:"
+    echo "$USED_PORTS" | while read -r used owner; do
+      [[ -n "$used" ]] && echo "  $used  ($owner)"
+    done
+  fi
+  read -rp "Server port [$SUGGESTED_PORT]: " PORT
+  PORT="${PORT:-$SUGGESTED_PORT}"
 
   echo ""
   echo "AWS SES configuration (required for email authentication):"
@@ -95,6 +182,12 @@ if [[ "$SKIP_ENV" == "false" ]]; then
   echo ""
 fi
 
+# --- Port collision guard ---
+PORT_OWNER=$(port_owner "$PORT")
+if [[ -n "$PORT_OWNER" ]]; then
+  error "Port $PORT is already used by $PORT_OWNER. Pick a different port."
+fi
+
 # --- Create service user ---
 if ! id "$SERVICE_USER" &>/dev/null; then
   useradd --system --create-home --home-dir /home/$SERVICE_USER --shell /bin/bash "$SERVICE_USER"
@@ -106,7 +199,22 @@ else
 fi
 
 # --- Set up sudoers for service restart + nginx sync ---
-SUDOERS_FILE="/etc/sudoers.d/$SERVICE_USER"
+# One file per instance, so setting up a second instance can't revoke the first
+# instance's ability to restart and reload itself during a deploy.
+# A pre-multi-instance install left a single /etc/sudoers.d/idlerpg granting rights
+# over the primary service. Its contents already match the primary's names, so rename
+# it into the new scheme rather than deleting it — dropping it while installing a
+# *second* instance would silently break the primary's deploys.
+LEGACY_SUDOERS="/etc/sudoers.d/$SERVICE_USER"
+if [[ -f "$LEGACY_SUDOERS" ]]; then
+  if [[ -z "$INSTANCE" || -f "/etc/sudoers.d/$SERVICE_USER-default" ]]; then
+    rm "$LEGACY_SUDOERS"
+    warn "Removed superseded legacy sudoers file $LEGACY_SUDOERS"
+  else
+    mv "$LEGACY_SUDOERS" "/etc/sudoers.d/$SERVICE_USER-default"
+    warn "Migrated $LEGACY_SUDOERS -> /etc/sudoers.d/$SERVICE_USER-default (primary instance)"
+  fi
+fi
 cat > "$SUDOERS_FILE" <<SUDOERS
 $SERVICE_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart $SERVICE_NAME
 $SERVICE_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl reload nginx
@@ -114,7 +222,7 @@ $SERVICE_USER ALL=(ALL) NOPASSWD: /usr/sbin/nginx -t
 $SERVICE_USER ALL=(ALL) NOPASSWD: /bin/cp /tmp/* /etc/nginx/sites-available/$NGINX_CONF
 SUDOERS
 chmod 440 "$SUDOERS_FILE"
-info "Sudoers: $SERVICE_USER can restart $SERVICE_NAME, sync nginx config, reload nginx"
+info "Sudoers: $SERVICE_USER can restart $SERVICE_NAME, sync $NGINX_CONF, reload nginx"
 
 # --- Clone or update repo ---
 if [[ -d "$INSTALL_DIR/.git" ]]; then
@@ -152,15 +260,20 @@ chown -R "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
 info "Set ownership to $SERVICE_USER"
 
 # --- Install systemd service ---
-cp "$INSTALL_DIR/deploy/idle-party-rpg.service" "/etc/systemd/system/$SERVICE_NAME.service"
+SCRIPT_DIR="$INSTALL_DIR/deploy"
+sed -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+    -e "s|{{SERVICE_USER}}|$SERVICE_USER|g" \
+    -e "s|{{SERVICE_NAME}}|$SERVICE_NAME|g" \
+    -e "s|{{INSTANCE_LABEL}}|$INSTANCE_LABEL|g" \
+    "$SCRIPT_DIR/idle-party-rpg.service.template" > "/etc/systemd/system/$SERVICE_NAME.service"
 systemctl daemon-reload
 systemctl enable "$SERVICE_NAME"
-systemctl start "$SERVICE_NAME"
-info "systemd service installed and started"
+systemctl restart "$SERVICE_NAME"
+info "systemd service $SERVICE_NAME installed and started"
 
 # --- Install nginx config ---
-SCRIPT_DIR="$INSTALL_DIR/deploy"
-sed "s/{{DOMAIN}}/$DOMAIN/g" "$SCRIPT_DIR/ipr-site.conf.template" > "/etc/nginx/sites-available/$NGINX_CONF"
+sed -e "s/{{DOMAIN}}/$DOMAIN/g" -e "s/{{PORT}}/$PORT/g" \
+    "$SCRIPT_DIR/ipr-site.conf.template" > "/etc/nginx/sites-available/$NGINX_CONF"
 
 if [[ -L "/etc/nginx/sites-enabled/$NGINX_CONF" ]]; then
   rm "/etc/nginx/sites-enabled/$NGINX_CONF"
@@ -175,34 +288,77 @@ fi
 
 nginx -t || error "nginx config test failed"
 systemctl reload nginx
-info "nginx configured for $DOMAIN"
+info "nginx configured for $DOMAIN -> localhost:$PORT"
+
+# --- Optional HTTPS via certbot ---
+# Skip this if TLS terminates upstream (Cloudflare proxy, another load balancer);
+# nginx then just serves plain HTTP on :80 behind the proxy.
+if [[ -z "$USE_CERTBOT" ]]; then
+  echo ""
+  echo "HTTPS: certbot issues a Let's Encrypt certificate directly on this server."
+  echo "Skip it if TLS already terminates upstream (e.g. the Cloudflare proxy)."
+  read -rp "Set up HTTPS with certbot for $DOMAIN? (y/N): " CERTBOT_ANSWER
+  if [[ "$CERTBOT_ANSWER" == "y" || "$CERTBOT_ANSWER" == "Y" ]]; then
+    USE_CERTBOT="yes"
+  else
+    USE_CERTBOT="no"
+  fi
+fi
+
+if [[ "$USE_CERTBOT" == "yes" ]]; then
+  if ! command -v certbot >/dev/null 2>&1; then
+    warn "certbot is not installed — installing it now..."
+    apt-get update
+    apt-get install -y certbot python3-certbot-nginx || \
+      error "Failed to install certbot. Install it manually, then run: certbot --nginx -d $DOMAIN"
+  fi
+  # certbot rewrites the site file in place to add the TLS server block. sync-nginx.sh
+  # detects a certbot-managed config and leaves it alone, so deploys won't clobber it.
+  certbot --nginx -d "$DOMAIN" || error "certbot failed for $DOMAIN. Fix DNS, then run: certbot --nginx -d $DOMAIN"
+  info "HTTPS enabled for $DOMAIN"
+  warn "$NGINX_CONF is now certbot-managed — deploys will stop auto-syncing it."
+  warn "If the repo's nginx template changes, re-run this script to pick it up."
+else
+  info "Skipped certbot — nginx serves plain HTTP on :80 (expects TLS upstream)"
+fi
 
 # --- Done ---
 echo ""
-echo "=== Setup Complete ==="
+echo "=== Setup Complete ($INSTANCE_LABEL) ==="
 echo ""
 echo "  Game server:  systemctl status $SERVICE_NAME"
 echo "  Server logs:  journalctl -u $SERVICE_NAME -f"
 echo "  nginx config: /etc/nginx/sites-available/$NGINX_CONF"
 echo "  App env:      $INSTALL_DIR/.env"
+echo "  Game data:    $INSTALL_DIR/data/"
 echo ""
 echo "=== Next Steps ==="
 echo ""
-echo "  1. Set up HTTPS:"
-echo "     sudo apt install certbot python3-certbot-nginx"
-echo "     sudo certbot --nginx -d $DOMAIN"
+if [[ "$USE_CERTBOT" == "yes" ]]; then
+  echo "  1. HTTPS is live via certbot. Confirm renewal is armed:"
+  echo "     systemctl status certbot.timer"
+else
+  echo "  1. Point $DOMAIN at this server and terminate TLS upstream."
+  echo "     With Cloudflare:"
+  echo "     - A record for $DOMAIN -> $(hostname -I | awk '{print $1}'), proxy enabled (orange cloud)"
+  echo "     - SSL/TLS mode: Full (nginx serves plain HTTP on :80 behind the proxy)"
+  echo "     - Enable WebSockets under Network (the game runs over a WS connection)"
+fi
 echo ""
-echo "  2. Set up SSH key for the $SERVICE_USER user:"
+echo "  2. Set up SSH key for the $SERVICE_USER user (skip if already done):"
 echo "     sudo mkdir -p /home/$SERVICE_USER/.ssh"
 echo "     sudo ssh-keygen -t ed25519 -f /home/$SERVICE_USER/.ssh/id_deploy -N ''"
-echo "     sudo cat /home/$SERVICE_USER/.ssh/id_deploy.pub | sudo tee /home/$SERVICE_USER/.ssh/authorized_keys"
+echo "     sudo cat /home/$SERVICE_USER/.ssh/id_deploy.pub | sudo tee -a /home/$SERVICE_USER/.ssh/authorized_keys"
 echo "     sudo chown -R $SERVICE_USER:$SERVICE_USER /home/$SERVICE_USER/.ssh"
 echo "     sudo chmod 700 /home/$SERVICE_USER/.ssh && sudo chmod 600 /home/$SERVICE_USER/.ssh/authorized_keys"
 echo ""
-echo "  3. Add GitHub Actions secrets for auto-deploy:"
+echo "  3. Add GitHub Actions secrets for auto-deploy (shared by all instances):"
 echo "     SSH_HOST  = $(hostname -I | awk '{print $1}')"
 echo "     SSH_USER  = $SERVICE_USER"
 echo "     SSH_KEY   = (contents of /home/$SERVICE_USER/.ssh/id_deploy)"
 echo ""
-echo "  4. Test: curl http://$DOMAIN"
+echo "     Deploy fans out over every /opt/idle-party-rpg* install it finds,"
+echo "     so this instance is picked up automatically on the next push to main."
+echo ""
+echo "  4. Test: curl -H 'Host: $DOMAIN' http://localhost"
 echo ""


### PR DESCRIPTION
## What

Lets several independent games run on one server, each behind its own domain — e.g. `game1.idlepartyrpg.com` and `game2.idlepartyrpg.com`.

```bash
sudo bash setup-prod.sh --instance game2
```

| | Primary | `--instance game2` |
|---|---|---|
| Install dir | `/opt/idle-party-rpg` | `/opt/idle-party-rpg-game2` |
| Service | `idle-party-rpg` | `idle-party-rpg-game2` |
| nginx site | `ipr-site.conf` | `ipr-site-game2.conf` |
| sudoers | `idlerpg-default` | `idlerpg-game2` |
| Game data | `/opt/idle-party-rpg/data/` | `/opt/idle-party-rpg-game2/data/` |

Omitting `--instance` reproduces the existing single-instance layout exactly.

## Why

The application was already instance-safe: every data path (`JsonFileStore`, `data/sessions`, all the `ASSET_KIND_INFO` artwork mounts) resolves against the process cwd, so a second install directory gets an entirely separate world — players, accounts, guilds, chat, CMS content — for free. The client build is same-origin with no baked-in server URL, and session/`_dt` cookies are host-only, so two subdomains don't collide.

The blocker was purely in the deploy tooling, which hardcoded one install dir, one service name, one nginx site, and one port. Running `setup-prod.sh` a second time **clobbered the first instance** rather than adding a second.

## Changes

**`setup-prod.sh`**
- `--instance NAME` derives install dir, service name, nginx site, and sudoers file. `--help` documents the layout.
- Scans sibling installs' `.env` for claimed ports, suggests the next free one, and refuses a collision outright.
- Per-instance sudoers files. Previously one `/etc/sudoers.d/idlerpg` named a single service, so installing instance 2 would silently revoke instance 1's ability to restart itself on deploy. A legacy single-instance file is *migrated* to `idlerpg-default` rather than deleted — deleting it during an `--instance` run would break the primary.
- Offers certbot interactively (default no) instead of only printing instructions, with `--certbot` / `--no-certbot` to answer up front. The skip path spells out the Cloudflare setup: A record proxied, SSL/TLS **Full**, and **WebSockets** enabled under Network.

**`deploy/idle-party-rpg.service` → `.service.template`** — the unit hardcoded `WorkingDirectory` and `EnvironmentFile` as `/opt/idle-party-rpg`, so a copied unit would have run instance 1's code against instance 1's data.

**`deploy/ipr-site.conf.template`** — gains `{{PORT}}`. Only `{{DOMAIN}}` was substituted before, so instance 2 would have proxied its traffic straight into instance 1 on `:3001`.

**`deploy/sync-nginx.sh`** — derives all paths from its own location and reads domain + port from its own `.env`, so a deploy can only touch its own site file. Also skips certbot-managed configs.

**`.github/workflows/deploy.yml`** — fans out over every `/opt/idle-party-rpg*` install. New instances are picked up with no workflow change; one instance failing doesn't block the others, and the job reports failures at the end.

## Reviewer notes

**Pre-existing bug fixed in passing:** `sync-nginx.sh` re-renders the site file from the repo template on every deploy, which would have wiped certbot's TLS server block. It now detects `managed by Certbot` and leaves the file alone. This was already true before this PR — it just becomes reachable now that the script offers certbot.

**Two bugs the sandbox testing caught**, both pre-existing patterns carried forward:
- The `APP_URL` → domain parse used `sed 's|APP_URL=https\?://||'`. `\?` is GNU-only; under BSD sed it produced `APP_URL=https:game1.example.com`. Rewritten portably.
- The new port scan initially used bash 4 associative arrays. Rewritten as a plain string list so it runs on bash 3.2 and the scripts can be smoke-tested off the server.

**Not changed:** magic-link emails are hardcoded "Idle Party RPG" in `server/src/auth/EmailService.ts:57` — only the link URL differs per instance, so a player on both servers gets two indistinguishable sign-in emails. Fixing that is an app change (a `SERVER_NAME` env threaded into the subject) beyond the scope of deploy config.

**No patch notes / no `GAME_VERSION` bump** — nothing here is player-visible.

## Testing

No TypeScript changed, so CI's typecheck/test/build is unaffected. The shell changes were exercised against sandboxed fake instances rather than eyeballed:

- **Instance isolation** — two simulated installs on ports 3001/3002; changing instance 2's port re-rendered only its own site file and left instance 1 at 3001.
- **Idempotence** — steady-state runs correctly report "nginx config unchanged".
- **certbot guard** — marked a config certbot-managed, drifted the template, confirmed the TLS line survived.
- **Port logic**, 3 scenarios — new instance picks the first free port (3003 with 3001/3002/3004 taken); re-running an existing instance excludes its own port; empty root suggests 3001 with no false collisions.
- **sudoers migration**, 4 states — primary-with-legacy, instance-with-legacy, instance-with-both, and clean multi-instance.
- **Failure modes** — an unexpected install dir name exits non-zero with a clear message; `--help` and unknown-arg handling verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)